### PR TITLE
Fix typo in readme & add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,20 @@
+approvers:
+- munnerz
+- joshvanl
+- meyskens
+- wallrj
+- jakexks
+- maelvls
+- irbekrm
+- sgtcodfish
+- inteon
+reviewers:
+- munnerz
+- joshvanl
+- meyskens
+- wallrj
+- jakexks
+- maelvls
+- irbekrm
+- sgtcodfish
+- inteon

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See `./internal/testsetups/simple` for an example of creating an issuer based on
 ⚠️ Warning: This library's API is still subject to change. Developers using this library will have to update their
 code when updating to a newer version.
 
-0. Currently, this library is used to build production Issuers, but no open-source Issuers/ examples are available yet. We advice to use this library only for experimentation.
+0. Currently, this library is used to build production Issuers, but no open-source Issuers/ examples are available yet. We advise to use this library only for experimentation.
 1. Once we have an open-source Issuer
 that uses this library & we have an example project that shows how to use this library, we will start advising developers to build all new issuers on top of this library.
 2. Once we have a 2nd or 3rd open-source Issuer that uses this library, we should be able to guarantee more stability.


### PR DESCRIPTION
I forgot to fix this typo: https://github.com/cert-manager/issuer-lib/pull/7#discussion_r1205783067
& the repo was still missing an OWNERS file.