### PR TITLE
Add support for Kubernetes CSR resources

### DIFF
--- a/api/v1alpha1/issuer_interface.go
+++ b/api/v1alpha1/issuer_interface.go
@@ -28,4 +28,5 @@ type Issuer interface {
 	runtime.Object
 	metav1.Object
 	GetStatus() *IssuerStatus
+	GetIssuerTypeIdentifier() string
 }

--- a/api/v1alpha1/issuer_interface.go
+++ b/api/v1alpha1/issuer_interface.go
@@ -28,5 +28,14 @@ type Issuer interface {
 	runtime.Object
 	metav1.Object
 	GetStatus() *IssuerStatus
+
+	// GetIssuerTypeIdentifier returns a string that uniquely identifies the
+	// issuer type. This should be a constant across all instances of this
+	// issuer type. This string is used as a prefix when determining the
+	// issuer type for a Kubernetes CertificateSigningRequest resource based
+	// on the issuerName field. The value should be formatted as follows:
+	// "<issuer resource (plural)>.<issuer group>". For example, the value
+	// "simpleclusterissuers.issuer.cert-manager.io" will match all CSRs
+	// with an issuerName set to eg. "simpleclusterissuers.issuer.cert-manager.io/issuer1".
 	GetIssuerTypeIdentifier() string
 }

--- a/conditions/certificaterequest_test.go
+++ b/conditions/certificaterequest_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+)
+
+// We are using a random time generator to generate random times for the
+// fakeClock. This will result in different times for each test run and
+// should make sure we don't incorrectly rely on `time.Now()` in the code.
+// WARNING: This approach does not guarantee that incorrect use of `time.Now()`
+// is always detected, but after a few test runs it should be very unlikely.
+func randomTime() time.Time {
+	min := time.Date(1970, 1, 0, 0, 0, 0, 0, time.UTC).Unix()
+	max := time.Date(2070, 1, 0, 0, 0, 0, 0, time.UTC).Unix()
+	delta := max - min
+
+	sec := rand.Int63n(delta) + min
+	return time.Unix(sec, 0)
+}
+
+func TestSetCertificateRequestStatusCondition(t *testing.T) {
+	type testCase struct {
+		name string
+
+		existingConditions []cmapi.CertificateRequestCondition
+		patchConditions    []cmapi.CertificateRequestCondition
+		conditionType      cmapi.CertificateRequestConditionType
+		status             cmmeta.ConditionStatus
+
+		expectedCondition *cmapi.CertificateRequestCondition
+		expectNewEntry    bool
+	}
+
+	fakeTime1 := randomTime()
+	fakeTimeObj1 := metav1.NewTime(fakeTime1)
+
+	fakeTime2 := randomTime()
+	fakeTimeObj2 := metav1.NewTime(fakeTime2)
+	fakeClock2 := clocktesting.NewFakeClock(fakeTime2)
+
+	testCases := []testCase{
+		{
+			name: "if the condition does NOT change its status, the last transition time should not be updated",
+			existingConditions: []cmapi.CertificateRequestCondition{
+				{
+					Type:   cmapi.CertificateRequestConditionReady,
+					Status: cmmeta.ConditionTrue,
+				},
+			},
+			patchConditions: []cmapi.CertificateRequestCondition{},
+			conditionType:   cmapi.CertificateRequestConditionReady,
+			status:          cmmeta.ConditionTrue,
+
+			expectedCondition: &cmapi.CertificateRequestCondition{
+				Type:               cmapi.CertificateRequestConditionReady,
+				Status:             cmmeta.ConditionTrue,
+				LastTransitionTime: &fakeTimeObj1,
+			},
+			expectNewEntry: true,
+		},
+		{
+			name: "if the condition DOES change its status, the last transition time should be updated",
+			existingConditions: []cmapi.CertificateRequestCondition{
+				{
+					Type:   cmapi.CertificateRequestConditionReady,
+					Status: cmmeta.ConditionTrue,
+				},
+			},
+			patchConditions: []cmapi.CertificateRequestCondition{},
+			conditionType:   cmapi.CertificateRequestConditionReady,
+			status:          cmmeta.ConditionFalse,
+
+			expectedCondition: &cmapi.CertificateRequestCondition{
+				Type:               cmapi.CertificateRequestConditionReady,
+				Status:             cmmeta.ConditionFalse,
+				LastTransitionTime: &fakeTimeObj2,
+			},
+			expectNewEntry: true,
+		},
+		{
+			name: "if the patch contains already contains the condition, it should get overwritten",
+			existingConditions: []cmapi.CertificateRequestCondition{
+				{
+					Type:   cmapi.CertificateRequestConditionReady,
+					Status: cmmeta.ConditionTrue,
+				},
+			},
+			patchConditions: []cmapi.CertificateRequestCondition{
+				{
+					Type:   cmapi.CertificateRequestConditionReady,
+					Status: cmmeta.ConditionTrue,
+				},
+			},
+			conditionType: cmapi.CertificateRequestConditionReady,
+			status:        cmmeta.ConditionTrue,
+
+			expectedCondition: &cmapi.CertificateRequestCondition{
+				Type:               cmapi.CertificateRequestConditionReady,
+				Status:             cmmeta.ConditionTrue,
+				LastTransitionTime: &fakeTimeObj1,
+			},
+			expectNewEntry: false,
+		},
+		{
+			name: "if the patch contains another condition type, it should get added",
+			existingConditions: []cmapi.CertificateRequestCondition{
+				{
+					Type:   cmapi.CertificateRequestConditionReady,
+					Status: cmmeta.ConditionTrue,
+				},
+			},
+			patchConditions: []cmapi.CertificateRequestCondition{
+				{
+					Type:   cmapi.CertificateRequestConditionReady,
+					Status: cmmeta.ConditionTrue,
+				},
+			},
+			conditionType: cmapi.CertificateRequestConditionApproved,
+			status:        cmmeta.ConditionTrue,
+
+			expectedCondition: &cmapi.CertificateRequestCondition{
+				Type:               cmapi.CertificateRequestConditionApproved,
+				Status:             cmmeta.ConditionTrue,
+				LastTransitionTime: &fakeTimeObj2,
+			},
+			expectNewEntry: true,
+		},
+	}
+
+	defaultConditions := func(t *testing.T, conditions []cmapi.CertificateRequestCondition) []cmapi.CertificateRequestCondition {
+		t.Helper()
+
+		for i := range conditions {
+			if conditions[i].LastTransitionTime != nil ||
+				conditions[i].Reason != "" ||
+				conditions[i].Message != "" {
+				t.Fatal("this field is managed by the test and should not be set")
+			}
+			conditions[i].LastTransitionTime = &fakeTimeObj1
+			conditions[i].Reason = "OldReason"
+			conditions[i].Message = "OldMessage"
+		}
+
+		return conditions
+	}
+
+	for _, test := range testCases {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			test.existingConditions = defaultConditions(t, test.existingConditions)
+			test.patchConditions = defaultConditions(t, test.patchConditions)
+
+			patchConditions := append([]cmapi.CertificateRequestCondition{}, test.patchConditions...)
+
+			cond, time := SetCertificateRequestStatusCondition(
+				fakeClock2,
+				test.existingConditions,
+				&patchConditions,
+				test.conditionType,
+				test.status,
+				"NewReason",
+				"NewMessage",
+			)
+
+			if test.expectedCondition.Reason != "" ||
+				test.expectedCondition.Message != "" {
+				t.Fatal("this field is managed by the test and should not be set")
+			}
+			test.expectedCondition.Reason = "NewReason"
+			test.expectedCondition.Message = "NewMessage"
+			require.Equal(t, test.expectedCondition, cond)
+			require.Equal(t, &fakeTimeObj2, time)
+
+			// Check that the patchConditions slice got a new entry if expected
+			if test.expectNewEntry {
+				require.Equal(t, len(test.patchConditions)+1, len(patchConditions))
+			} else {
+				require.Equal(t, len(test.patchConditions), len(patchConditions))
+			}
+
+			// Make sure only the expected condition in the patchConditions slice got updated
+			for _, c := range patchConditions {
+				if c.Type == test.conditionType {
+					require.Equal(t, test.expectedCondition, &c)
+					continue
+				}
+
+				for _, ec := range test.patchConditions {
+					if ec.Type == c.Type {
+						require.Equal(t, ec, c)
+					}
+				}
+			}
+		})
+	}
+}

--- a/conditions/certificatesigningrequest.go
+++ b/conditions/certificatesigningrequest.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	certificatesv1 "k8s.io/api/certificates/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
+)
+
+// Update the status with the provided condition details & return
+// the added condition.
+func SetCertificateSigningRequestStatusCondition(
+	clock clock.PassiveClock,
+	existingConditions []certificatesv1.CertificateSigningRequestCondition,
+	patchConditions *[]certificatesv1.CertificateSigningRequestCondition,
+	conditionType certificatesv1.RequestConditionType,
+	status v1.ConditionStatus,
+	reason, message string,
+) (*certificatesv1.CertificateSigningRequestCondition, *metav1.Time) {
+	newCondition := certificatesv1.CertificateSigningRequestCondition{
+		Type:    conditionType,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	}
+
+	nowTime := metav1.NewTime(clock.Now())
+	newCondition.LastUpdateTime = nowTime
+	newCondition.LastTransitionTime = nowTime
+
+	// Reset the LastTransitionTime if the status hasn't changed
+	for _, cond := range existingConditions {
+		if cond.Type != conditionType {
+			continue
+		}
+
+		// If this update doesn't contain a state transition, we don't update
+		// the conditions LastTransitionTime to Now()
+		if cond.Status == status {
+			newCondition.LastTransitionTime = cond.LastTransitionTime
+		}
+	}
+
+	// Search through existing conditions
+	for idx, cond := range *patchConditions {
+		// Skip unrelated conditions
+		if cond.Type != conditionType {
+			continue
+		}
+
+		// Overwrite the existing condition
+		(*patchConditions)[idx] = newCondition
+
+		return &newCondition, &nowTime
+	}
+
+	// If we've not found an existing condition of this type, we simply insert
+	// the new condition into the slice.
+	*patchConditions = append(*patchConditions, newCondition)
+
+	return &newCondition, &nowTime
+}
+
+func GetCertificateSigningRequestStatusCondition(
+	conditions []certificatesv1.CertificateSigningRequestCondition,
+	conditionType certificatesv1.RequestConditionType,
+) *certificatesv1.CertificateSigningRequestCondition {
+	for _, cond := range conditions {
+		if cond.Type == conditionType {
+			return &cond
+		}
+	}
+	return nil
+}

--- a/conditions/certificatesigningrequest_test.go
+++ b/conditions/certificatesigningrequest_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+)
+
+func TestSetCertificateSigningRequestStatusCondition(t *testing.T) {
+	type testCase struct {
+		name string
+
+		existingConditions []certificatesv1.CertificateSigningRequestCondition
+		patchConditions    []certificatesv1.CertificateSigningRequestCondition
+		conditionType      certificatesv1.RequestConditionType
+		status             v1.ConditionStatus
+
+		expectedCondition *certificatesv1.CertificateSigningRequestCondition
+		expectNewEntry    bool
+	}
+
+	fakeTime1 := randomTime()
+	fakeTimeObj1 := metav1.NewTime(fakeTime1)
+
+	fakeTime2 := randomTime()
+	fakeTimeObj2 := metav1.NewTime(fakeTime2)
+	fakeClock2 := clocktesting.NewFakeClock(fakeTime2)
+
+	testCases := []testCase{
+		{
+			name: "if the condition does NOT change its status, the last transition time should not be updated",
+			existingConditions: []certificatesv1.CertificateSigningRequestCondition{
+				{
+					Type:   certificatesv1.CertificateApproved,
+					Status: v1.ConditionTrue,
+				},
+			},
+			patchConditions: []certificatesv1.CertificateSigningRequestCondition{},
+			conditionType:   certificatesv1.CertificateApproved,
+			status:          v1.ConditionTrue,
+
+			expectedCondition: &certificatesv1.CertificateSigningRequestCondition{
+				Type:               certificatesv1.CertificateApproved,
+				Status:             v1.ConditionTrue,
+				LastTransitionTime: fakeTimeObj1,
+			},
+			expectNewEntry: true,
+		},
+		{
+			name: "if the condition DOES change its status, the last transition time should be updated",
+			existingConditions: []certificatesv1.CertificateSigningRequestCondition{
+				{
+					Type:   certificatesv1.CertificateApproved,
+					Status: v1.ConditionTrue,
+				},
+			},
+			patchConditions: []certificatesv1.CertificateSigningRequestCondition{},
+			conditionType:   certificatesv1.CertificateApproved,
+			status:          v1.ConditionFalse,
+
+			expectedCondition: &certificatesv1.CertificateSigningRequestCondition{
+				Type:               certificatesv1.CertificateApproved,
+				Status:             v1.ConditionFalse,
+				LastTransitionTime: fakeTimeObj2,
+			},
+			expectNewEntry: true,
+		},
+		{
+			name: "if the patch contains already contains the condition, it should get overwritten",
+			existingConditions: []certificatesv1.CertificateSigningRequestCondition{
+				{
+					Type:   certificatesv1.CertificateApproved,
+					Status: v1.ConditionTrue,
+				},
+			},
+			patchConditions: []certificatesv1.CertificateSigningRequestCondition{
+				{
+					Type:   certificatesv1.CertificateApproved,
+					Status: v1.ConditionTrue,
+				},
+			},
+			conditionType: certificatesv1.CertificateApproved,
+			status:        v1.ConditionTrue,
+
+			expectedCondition: &certificatesv1.CertificateSigningRequestCondition{
+				Type:               certificatesv1.CertificateApproved,
+				Status:             v1.ConditionTrue,
+				LastTransitionTime: fakeTimeObj1,
+			},
+			expectNewEntry: false,
+		},
+		{
+			name: "if the patch contains another condition type, it should get added",
+			existingConditions: []certificatesv1.CertificateSigningRequestCondition{
+				{
+					Type:   certificatesv1.CertificateApproved,
+					Status: v1.ConditionTrue,
+				},
+			},
+			patchConditions: []certificatesv1.CertificateSigningRequestCondition{
+				{
+					Type:   certificatesv1.CertificateApproved,
+					Status: v1.ConditionTrue,
+				},
+			},
+			conditionType: certificatesv1.CertificateDenied,
+			status:        v1.ConditionTrue,
+
+			expectedCondition: &certificatesv1.CertificateSigningRequestCondition{
+				Type:               certificatesv1.CertificateDenied,
+				Status:             v1.ConditionTrue,
+				LastTransitionTime: fakeTimeObj2,
+			},
+			expectNewEntry: true,
+		},
+	}
+
+	defaultConditions := func(t *testing.T, conditions []certificatesv1.CertificateSigningRequestCondition) []certificatesv1.CertificateSigningRequestCondition {
+		t.Helper()
+
+		for i := range conditions {
+			if !conditions[i].LastUpdateTime.IsZero() ||
+				!conditions[i].LastTransitionTime.IsZero() ||
+				conditions[i].Reason != "" ||
+				conditions[i].Message != "" {
+				t.Fatal("this field is managed by the test and should not be set")
+			}
+			conditions[i].LastUpdateTime = fakeTimeObj1
+			conditions[i].LastTransitionTime = fakeTimeObj1
+			conditions[i].Reason = "OldReason"
+			conditions[i].Message = "OldMessage"
+		}
+
+		return conditions
+	}
+
+	for _, test := range testCases {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			test.existingConditions = defaultConditions(t, test.existingConditions)
+			test.patchConditions = defaultConditions(t, test.patchConditions)
+
+			patchConditions := append([]certificatesv1.CertificateSigningRequestCondition{}, test.patchConditions...)
+
+			cond, time := SetCertificateSigningRequestStatusCondition(
+				fakeClock2,
+				test.existingConditions,
+				&patchConditions,
+				test.conditionType,
+				test.status,
+				"NewReason",
+				"NewMessage",
+			)
+
+			if !test.expectedCondition.LastUpdateTime.IsZero() ||
+				test.expectedCondition.Reason != "" ||
+				test.expectedCondition.Message != "" {
+				t.Fatal("this field is managed by the test and should not be set")
+			}
+			test.expectedCondition.LastUpdateTime = fakeTimeObj2
+			test.expectedCondition.Reason = "NewReason"
+			test.expectedCondition.Message = "NewMessage"
+			require.Equal(t, test.expectedCondition, cond)
+			require.Equal(t, &fakeTimeObj2, time)
+
+			// Check that the patchConditions slice got a new entry if expected
+			if test.expectNewEntry {
+				require.Equal(t, len(test.patchConditions)+1, len(patchConditions))
+			} else {
+				require.Equal(t, len(test.patchConditions), len(patchConditions))
+			}
+
+			// Make sure only the expected condition in the patchConditions slice got updated
+			for _, c := range patchConditions {
+				if c.Type == test.conditionType {
+					require.Equal(t, test.expectedCondition, &c)
+					continue
+				}
+
+				for _, ec := range test.patchConditions {
+					if ec.Type == c.Type {
+						require.Equal(t, ec, c)
+					}
+				}
+			}
+		})
+	}
+}

--- a/conditions/issuer_test.go
+++ b/conditions/issuer_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"testing"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+)
+
+func TestSetIssuerStatusCondition(t *testing.T) {
+	type testCase struct {
+		name string
+
+		existingConditions []cmapi.IssuerCondition
+		patchConditions    []cmapi.IssuerCondition
+		conditionType      cmapi.IssuerConditionType
+		status             cmmeta.ConditionStatus
+
+		expectedCondition *cmapi.IssuerCondition
+		expectNewEntry    bool
+	}
+
+	fakeTime1 := randomTime()
+	fakeTimeObj1 := metav1.NewTime(fakeTime1)
+
+	fakeTime2 := randomTime()
+	fakeTimeObj2 := metav1.NewTime(fakeTime2)
+	fakeClock2 := clocktesting.NewFakeClock(fakeTime2)
+
+	testCases := []testCase{
+		{
+			name: "if the condition does NOT change its status, the last transition time should not be updated",
+			existingConditions: []cmapi.IssuerCondition{
+				{
+					Type:   cmapi.IssuerConditionReady,
+					Status: cmmeta.ConditionTrue,
+				},
+			},
+			patchConditions: []cmapi.IssuerCondition{},
+			conditionType:   cmapi.IssuerConditionReady,
+			status:          cmmeta.ConditionTrue,
+
+			expectedCondition: &cmapi.IssuerCondition{
+				Type:               cmapi.IssuerConditionReady,
+				Status:             cmmeta.ConditionTrue,
+				LastTransitionTime: &fakeTimeObj1,
+			},
+			expectNewEntry: true,
+		},
+		{
+			name: "if the condition DOES change its status, the last transition time should be updated",
+			existingConditions: []cmapi.IssuerCondition{
+				{
+					Type:   cmapi.IssuerConditionReady,
+					Status: cmmeta.ConditionTrue,
+				},
+			},
+			patchConditions: []cmapi.IssuerCondition{},
+			conditionType:   cmapi.IssuerConditionReady,
+			status:          cmmeta.ConditionFalse,
+
+			expectedCondition: &cmapi.IssuerCondition{
+				Type:               cmapi.IssuerConditionReady,
+				Status:             cmmeta.ConditionFalse,
+				LastTransitionTime: &fakeTimeObj2,
+			},
+			expectNewEntry: true,
+		},
+		{
+			name: "if the patch contains already contains the condition, it should get overwritten",
+			existingConditions: []cmapi.IssuerCondition{
+				{
+					Type:   cmapi.IssuerConditionReady,
+					Status: cmmeta.ConditionTrue,
+				},
+			},
+			patchConditions: []cmapi.IssuerCondition{
+				{
+					Type:   cmapi.IssuerConditionReady,
+					Status: cmmeta.ConditionTrue,
+				},
+			},
+			conditionType: cmapi.IssuerConditionReady,
+			status:        cmmeta.ConditionTrue,
+
+			expectedCondition: &cmapi.IssuerCondition{
+				Type:               cmapi.IssuerConditionReady,
+				Status:             cmmeta.ConditionTrue,
+				LastTransitionTime: &fakeTimeObj1,
+			},
+			expectNewEntry: false,
+		},
+		{
+			name: "if the patch contains another condition type, it should get added",
+			existingConditions: []cmapi.IssuerCondition{
+				{
+					Type:   cmapi.IssuerConditionReady,
+					Status: cmmeta.ConditionTrue,
+				},
+			},
+			patchConditions: []cmapi.IssuerCondition{
+				{
+					Type:   cmapi.IssuerConditionReady,
+					Status: cmmeta.ConditionTrue,
+				},
+			},
+			conditionType: cmapi.IssuerConditionType("AnotherCondition"),
+			status:        cmmeta.ConditionTrue,
+
+			expectedCondition: &cmapi.IssuerCondition{
+				Type:               cmapi.IssuerConditionType("AnotherCondition"),
+				Status:             cmmeta.ConditionTrue,
+				LastTransitionTime: &fakeTimeObj2,
+			},
+			expectNewEntry: true,
+		},
+	}
+
+	defaultConditions := func(t *testing.T, conditions []cmapi.IssuerCondition) []cmapi.IssuerCondition {
+		t.Helper()
+
+		for i := range conditions {
+			if !conditions[i].LastTransitionTime.IsZero() ||
+				conditions[i].Reason != "" ||
+				conditions[i].Message != "" ||
+				conditions[i].ObservedGeneration != 0 {
+				t.Fatal("this field is managed by the test and should not be set")
+			}
+			conditions[i].LastTransitionTime = &fakeTimeObj1
+			conditions[i].Reason = "OldReason"
+			conditions[i].Message = "OldMessage"
+			conditions[i].ObservedGeneration = 7
+		}
+
+		return conditions
+	}
+
+	for _, test := range testCases {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			test.existingConditions = defaultConditions(t, test.existingConditions)
+			test.patchConditions = defaultConditions(t, test.patchConditions)
+
+			patchConditions := append([]cmapi.IssuerCondition{}, test.patchConditions...)
+
+			cond, time := SetIssuerStatusCondition(
+				fakeClock2,
+				test.existingConditions,
+				&patchConditions,
+				8,
+				test.conditionType,
+				test.status,
+				"NewReason",
+				"NewMessage",
+			)
+
+			if test.expectedCondition.Reason != "" ||
+				test.expectedCondition.Message != "" ||
+				test.expectedCondition.ObservedGeneration != 0 {
+				t.Fatal("this field is managed by the test and should not be set")
+			}
+			test.expectedCondition.Reason = "NewReason"
+			test.expectedCondition.Message = "NewMessage"
+			test.expectedCondition.ObservedGeneration = 8
+			require.Equal(t, test.expectedCondition, cond)
+			require.Equal(t, &fakeTimeObj2, time)
+
+			// Check that the patchConditions slice got a new entry if expected
+			if test.expectNewEntry {
+				require.Equal(t, len(test.patchConditions)+1, len(patchConditions))
+			} else {
+				require.Equal(t, len(test.patchConditions), len(patchConditions))
+			}
+
+			// Make sure only the expected condition in the patchConditions slice got updated
+			for _, c := range patchConditions {
+				if c.Type == test.conditionType {
+					require.Equal(t, test.expectedCondition, &c)
+					continue
+				}
+
+				for _, ec := range test.patchConditions {
+					if ec.Type == c.Type {
+						require.Equal(t, ec, c)
+					}
+				}
+			}
+		})
+	}
+}

--- a/controllers/certificaterequest_controller_integration_test.go
+++ b/controllers/certificaterequest_controller_integration_test.go
@@ -90,8 +90,8 @@ func TestCertificateRequestControllerIntegrationIssuerInitiallyNotFoundAndNotRea
 				MaxRetryDuration:   time.Minute,
 				EventSource:        kubeutil.NewEventStore(),
 				Client:             mgr.GetClient(),
-				Sign: func(_ context.Context, cr *cmapi.CertificateRequest, _ client.Object) ([]byte, error) {
-					atomic.AddUint64(&counters[extractIdFromNamespace(t, cr.Namespace)], 1)
+				Sign: func(_ context.Context, cr signer.CertificateRequestObject, _ v1alpha1.Issuer) ([]byte, error) {
+					atomic.AddUint64(&counters[extractIdFromNamespace(t, cr.GetNamespace())], 1)
 					return []byte("ok"), nil
 				},
 				EventRecorder: record.NewFakeRecorder(100),
@@ -227,7 +227,7 @@ func TestCertificateRequestControllerIntegrationSetCondition(t *testing.T) {
 				MaxRetryDuration:   time.Minute,
 				EventSource:        kubeutil.NewEventStore(),
 				Client:             mgr.GetClient(),
-				Sign: func(ctx context.Context, cr *cmapi.CertificateRequest, _ client.Object) ([]byte, error) {
+				Sign: func(ctx context.Context, cr signer.CertificateRequestObject, _ v1alpha1.Issuer) ([]byte, error) {
 					atomic.AddUint64(&counter, 1)
 					select {
 					case err := <-signResult:

--- a/controllers/certificatesigningrequest_controller.go
+++ b/controllers/certificatesigningrequest_controller.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
-	cmutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/util"
 	"github.com/go-logr/logr"
+	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -49,8 +51,8 @@ import (
 	"github.com/cert-manager/issuer-lib/internal/ssaclient"
 )
 
-// CertificateRequestReconciler reconciles a CertificateRequest object
-type CertificateRequestReconciler struct {
+// CertificateSigningRequestReconciler reconciles a CertificateRequest object
+type CertificateSigningRequestReconciler struct {
 	IssuerTypes        []v1alpha1.Issuer
 	ClusterIssuerTypes []v1alpha1.Issuer
 
@@ -72,15 +74,15 @@ type CertificateRequestReconciler struct {
 	PostSetupWithManager func(context.Context, schema.GroupVersionKind, ctrl.Manager, controller.Controller) error
 }
 
-func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, returnedError error) {
+func (r *CertificateSigningRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, returnedError error) {
 	logger := log.FromContext(ctx).WithName("Reconcile")
 
 	logger.V(2).Info("Starting reconcile loop", "name", req.Name, "namespace", req.Namespace)
 
-	result, crStatusPatch, returnedError := r.reconcileStatusPatch(logger, ctx, req)
-	logger.V(2).Info("Got StatusPatch result", "result", result, "patch", crStatusPatch, "error", returnedError)
-	if crStatusPatch != nil {
-		cr, patch, err := ssaclient.GenerateCertificateRequestStatusPatch(req.Name, req.Namespace, crStatusPatch)
+	result, csrStatusPatch, returnedError := r.reconcileStatusPatch(logger, ctx, req)
+	logger.V(2).Info("Got StatusPatch result", "result", result, "patch", csrStatusPatch, "error", returnedError)
+	if csrStatusPatch != nil {
+		cr, patch, err := ssaclient.GenerateCertificateSigningRequestStatusPatch(req.Name, req.Namespace, csrStatusPatch)
 		if err != nil {
 			return ctrl.Result{}, utilerrors.NewAggregate([]error{err, returnedError})
 		}
@@ -101,13 +103,13 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 	return result, returnedError
 }
 
-func (r *CertificateRequestReconciler) reconcileStatusPatch(
+func (r *CertificateSigningRequestReconciler) reconcileStatusPatch(
 	logger logr.Logger,
 	ctx context.Context,
 	req ctrl.Request,
-) (result ctrl.Result, crStatusPatch *cmapi.CertificateRequestStatus, returnedError error) {
-	var cr cmapi.CertificateRequest
-	if err := r.Client.Get(ctx, req.NamespacedName, &cr); err != nil && apierrors.IsNotFound(err) {
+) (result ctrl.Result, csrStatusPatch *certificatesv1.CertificateSigningRequestStatus, returnedError error) {
+	var csr certificatesv1.CertificateSigningRequest
+	if err := r.Client.Get(ctx, req.NamespacedName, &csr); err != nil && apierrors.IsNotFound(err) {
 		logger.V(1).Info("Not found. Ignoring.")
 		return result, nil, nil // done
 	} else if err != nil {
@@ -116,103 +118,48 @@ func (r *CertificateRequestReconciler) reconcileStatusPatch(
 
 	// Ignore CertificateRequest if it has not yet been assigned an approval
 	// status condition by an approval controller.
-	if !cmutil.CertificateRequestIsApproved(&cr) && !cmutil.CertificateRequestIsDenied(&cr) {
-		logger.V(1).Info("CertificateRequest has not been approved or denied. Ignoring.")
+	if !util.CertificateSigningRequestIsApproved(&csr) && !util.CertificateSigningRequestIsDenied(&csr) {
+		logger.V(1).Info("CertificateSigningRequest has not been approved or denied. Ignoring.")
 		return result, nil, nil // done
 	}
 
 	// Select first matching issuer type and construct an issuerObject and issuerName
-	issuerObject, issuerName := r.matchIssuerType(&cr)
+	issuerObject, issuerName, err := r.matchIssuerType(&csr)
 	// Ignore CertificateRequest if issuerRef doesn't match one of our issuer Types
-	if issuerObject == nil {
-		logger.V(1).Info("Foreign issuer. Ignoring.", "group", cr.Spec.IssuerRef.Group, "kind", cr.Spec.IssuerRef.Kind)
+	if err != nil {
+		logger.V(1).Info("Foreign issuer. Ignoring.", "error", err)
 		return result, nil, nil // done
 	}
 	issuerGvk := issuerObject.GetObjectKind().GroupVersionKind()
 
 	// Ignore CertificateRequest if it is already Ready
-	if cmutil.CertificateRequestHasCondition(&cr, cmapi.CertificateRequestCondition{
-		Type:   cmapi.CertificateRequestConditionReady,
-		Status: cmmeta.ConditionTrue,
-	}) {
-		logger.V(1).Info("CertificateRequest is Ready. Ignoring.")
+	if len(csr.Status.Certificate) > 0 {
+		logger.V(1).Info("CertificateSigningRequest is Ready. Ignoring.")
 		return result, nil, nil // done
 	}
 
 	// Ignore CertificateRequest if it is already Failed
-	if cmutil.CertificateRequestHasCondition(&cr, cmapi.CertificateRequestCondition{
-		Type:   cmapi.CertificateRequestConditionReady,
-		Status: cmmeta.ConditionFalse,
-		Reason: cmapi.CertificateRequestReasonFailed,
-	}) {
-		logger.V(1).Info("CertificateRequest is Failed. Ignoring.")
+	if util.CertificateSigningRequestIsFailed(&csr) {
+		logger.V(1).Info("CertificateSigningRequest is Failed. Ignoring.")
 		return result, nil, nil // done
 	}
 
-	// Ignore CertificateRequest if it is already Denied
-	if cmutil.CertificateRequestHasCondition(&cr, cmapi.CertificateRequestCondition{
-		Type:   cmapi.CertificateRequestConditionReady,
-		Status: cmmeta.ConditionFalse,
-		Reason: cmapi.CertificateRequestReasonDenied,
-	}) {
-		logger.V(1).Info("CertificateRequest already has a Ready condition with Denied Reason. Ignoring.")
+	// Ignore CertificateRequest if it is Denied
+	if util.CertificateSigningRequestIsDenied(&csr) {
+		logger.V(1).Info("CertificateSigningRequest is Denied. Ignoring.")
 		return result, nil, nil // done
 	}
 
-	// We now have a CertificateRequest that belongs to us so we are responsible
+	// We now have a CertificateSigningRequestStatus that belongs to us so we are responsible
 	// for updating its Status.
-	crStatusPatch = &cmapi.CertificateRequestStatus{}
-
-	// Add a Ready condition if one does not already exist. Set initial Status
-	// to Unknown.
-	if ready := cmutil.GetCertificateRequestCondition(&cr, cmapi.CertificateRequestConditionReady); ready == nil {
-		logger.V(1).Info("Initializing Ready condition")
-		conditions.SetCertificateRequestStatusCondition(
-			r.Clock,
-			cr.Status.Conditions,
-			&crStatusPatch.Conditions,
-			cmapi.CertificateRequestConditionReady,
-			cmmeta.ConditionUnknown,
-			v1alpha1.CertificateRequestConditionReasonInitializing,
-			fmt.Sprintf("%s has started reconciling this CertificateRequest", r.FieldOwner),
-		)
-		// To continue reconciling this CertificateRequest, we must re-run the reconcile loop
-		// after adding the Unknown Ready condition. This update will trigger a
-		// new reconcile loop, so we don't need to requeue here.
-		return result, crStatusPatch, nil // apply patch, done
-	}
-
-	if cmutil.CertificateRequestIsDenied(&cr) {
-		logger.V(1).Info("CertificateRequest has been denied. Marking as failed.")
-		_, failedAt := conditions.SetCertificateRequestStatusCondition(
-			r.Clock,
-			cr.Status.Conditions,
-			&crStatusPatch.Conditions,
-			cmapi.CertificateRequestConditionReady,
-			cmmeta.ConditionFalse,
-			cmapi.CertificateRequestReasonDenied,
-			"The CertificateRequest was denied by an approval controller",
-		)
-		crStatusPatch.FailureTime = failedAt.DeepCopy()
-		r.EventRecorder.Eventf(&cr, corev1.EventTypeNormal, "DetectedDenied", "Detected that the CR is denied, will update Ready condition")
-		return result, crStatusPatch, nil // done, apply patch
-	}
+	csrStatusPatch = &certificatesv1.CertificateSigningRequestStatus{}
 
 	if err := r.Client.Get(ctx, issuerName, issuerObject); err != nil && apierrors.IsNotFound(err) {
 		logger.V(1).Info("Issuer not found. Waiting for it to be created")
-		conditions.SetCertificateRequestStatusCondition(
-			r.Clock,
-			cr.Status.Conditions,
-			&crStatusPatch.Conditions,
-			cmapi.CertificateRequestConditionReady,
-			cmmeta.ConditionFalse,
-			cmapi.CertificateRequestReasonPending,
-			fmt.Sprintf("%s. Waiting for it to be created.", err),
-		)
-		r.EventRecorder.Eventf(&cr, corev1.EventTypeNormal, "WaitingForIssuerExist", "Waiting for the issuer to exist")
-		return result, crStatusPatch, nil // done, apply patch
+		r.EventRecorder.Eventf(&csr, corev1.EventTypeNormal, "WaitingForIssuerExist", "Waiting for the issuer to exist")
+		return result, csrStatusPatch, nil // done, apply patch
 	} else if err != nil {
-		r.EventRecorder.Eventf(&cr, corev1.EventTypeWarning, "UnexpectedError", "Got an unexpected error while processing the CR")
+		r.EventRecorder.Eventf(&csr, corev1.EventTypeWarning, "UnexpectedError", "Got an unexpected error while processing the CR")
 		return result, nil, fmt.Errorf("unexpected get error: %v", err) // retry
 	}
 
@@ -224,30 +171,12 @@ func (r *CertificateRequestReconciler) reconcileStatusPatch(
 		(readyCondition.Status != cmmeta.ConditionTrue) ||
 		(readyCondition.ObservedGeneration < issuerObject.GetGeneration()) {
 
-		message := ""
-		if readyCondition == nil {
-			message = "Issuer is not Ready yet. No ready condition found. Waiting for it to become ready."
-		} else if readyCondition.Status != cmmeta.ConditionTrue {
-			message = fmt.Sprintf("Issuer is not Ready yet. Current ready condition is \"%s\": %s. Waiting for it to become ready.", readyCondition.Reason, readyCondition.Message)
-		} else {
-			message = "Issuer is not Ready yet. Current ready condition is outdated. Waiting for it to become ready."
-		}
-
 		logger.V(1).Info("Issuer is not Ready yet. Waiting for it to become ready.", "issuer ready condition", readyCondition)
-		conditions.SetCertificateRequestStatusCondition(
-			r.Clock,
-			cr.Status.Conditions,
-			&crStatusPatch.Conditions,
-			cmapi.CertificateRequestConditionReady,
-			cmmeta.ConditionFalse,
-			cmapi.CertificateRequestReasonPending,
-			message,
-		)
-		r.EventRecorder.Eventf(&cr, corev1.EventTypeNormal, "WaitingForIssuerReady", "Waiting for the issuer to become ready")
-		return result, crStatusPatch, nil // done, apply patch
+		r.EventRecorder.Eventf(&csr, corev1.EventTypeNormal, "WaitingForIssuerReady", "Waiting for the issuer to become ready")
+		return result, csrStatusPatch, nil // done, apply patch
 	}
 
-	signedCertificate, err := r.Sign(log.IntoContext(ctx, logger), signer.CertificateRequestObjectFromCertificateRequest(&cr), issuerObject)
+	signedCertificate, err := r.Sign(log.IntoContext(ctx, logger), signer.CertificateRequestObjectFromCertificateSigningRequest(&csr), issuerObject)
 	if err != nil {
 		// An error in the issuer part of the operator should trigger a reconcile
 		// of the issuer's state.
@@ -260,74 +189,57 @@ func (r *CertificateRequestReconciler) reconcileStatusPatch(
 			}
 
 			logger.V(1).Error(err, "Temporary CertificateRequest error.")
-			conditions.SetCertificateRequestStatusCondition(
-				r.Clock,
-				cr.Status.Conditions,
-				&crStatusPatch.Conditions,
-				cmapi.CertificateRequestConditionReady,
-				cmmeta.ConditionFalse,
-				cmapi.CertificateRequestReasonPending,
-				"Issuer is not Ready yet. Current ready condition is outdated. Waiting for it to become ready.",
-			)
-			r.EventRecorder.Eventf(&cr, corev1.EventTypeWarning, "WaitingForIssuerReady", "Waiting for the issuer to become ready")
-			return result, crStatusPatch, nil // done, apply patch
+
+			r.EventRecorder.Eventf(&csr, corev1.EventTypeWarning, "WaitingForIssuerReady", "Waiting for the issuer to become ready")
+			return result, csrStatusPatch, nil // done, apply patch
 		}
 
 		didCustomConditionTransition := false
 
 		if targetCustom := new(signer.SetCertificateRequestConditionError); errors.As(err, targetCustom) {
 			logger.V(1).Info("Set CertificateRequestCondition error. Setting condition.", "error", err)
-			conditions.SetCertificateRequestStatusCondition(
+			conditions.SetCertificateSigningRequestStatusCondition(
 				r.Clock,
-				cr.Status.Conditions,
-				&crStatusPatch.Conditions,
-				targetCustom.ConditionType,
-				targetCustom.Status,
+				csr.Status.Conditions,
+				&csrStatusPatch.Conditions,
+				certificatesv1.RequestConditionType(targetCustom.ConditionType),
+				corev1.ConditionStatus(targetCustom.Status),
 				targetCustom.Reason,
 				targetCustom.Error(),
 			)
 
 			// check if the custom condition transitioned
-			currentCustom := cmutil.GetCertificateRequestCondition(&cr, targetCustom.ConditionType)
-			didCustomConditionTransition = currentCustom == nil || currentCustom.Status != targetCustom.Status
+			currentCustom := conditions.GetCertificateSigningRequestStatusCondition(csr.Status.Conditions, certificatesv1.RequestConditionType(targetCustom.ConditionType))
+			didCustomConditionTransition = currentCustom == nil || currentCustom.Status != corev1.ConditionStatus(targetCustom.Status)
 		}
 
 		// Check if we have still time to requeue & retry
 		isPendingError := errors.As(err, &signer.PendingError{})
 		isPermanentError := errors.As(err, &signer.PermanentError{})
-		pastMaxRetryDuration := r.Clock.Now().After(cr.CreationTimestamp.Add(r.MaxRetryDuration))
+		pastMaxRetryDuration := r.Clock.Now().After(csr.CreationTimestamp.Add(r.MaxRetryDuration))
 		if !isPendingError && (isPermanentError || pastMaxRetryDuration) {
 			// fail permanently
 			logger.V(1).Error(err, "Permanent CertificateRequest error. Marking as failed.")
-			_, failedAt := conditions.SetCertificateRequestStatusCondition(
+
+			conditions.SetCertificateSigningRequestStatusCondition(
 				r.Clock,
-				cr.Status.Conditions,
-				&crStatusPatch.Conditions,
-				cmapi.CertificateRequestConditionReady,
-				cmmeta.ConditionFalse,
+				csr.Status.Conditions,
+				&csrStatusPatch.Conditions,
+				certificatesv1.CertificateFailed,
+				corev1.ConditionTrue,
 				cmapi.CertificateRequestReasonFailed,
 				fmt.Sprintf("CertificateRequest has failed permanently: %s", err),
 			)
-			crStatusPatch.FailureTime = failedAt.DeepCopy()
-			r.EventRecorder.Eventf(&cr, corev1.EventTypeWarning, "PermanentError", "Failed permanently to sign CertificateRequest: %s", err)
-			return result, crStatusPatch, nil // done, apply patch
+			r.EventRecorder.Eventf(&csr, corev1.EventTypeWarning, "PermanentError", "Failed permanently to sign CertificateRequest: %s", err)
+			return result, csrStatusPatch, nil // done, apply patch
 		} else {
 			// retry
 			logger.V(1).Error(err, "Retryable CertificateRequest error.")
-			conditions.SetCertificateRequestStatusCondition(
-				r.Clock,
-				cr.Status.Conditions,
-				&crStatusPatch.Conditions,
-				cmapi.CertificateRequestConditionReady,
-				cmmeta.ConditionFalse,
-				cmapi.CertificateRequestReasonPending,
-				fmt.Sprintf("CertificateRequest is not ready yet: %s", err),
-			)
 
-			r.EventRecorder.Eventf(&cr, corev1.EventTypeWarning, "RetryableError", "Failed to sign CertificateRequest, will retry: %s", err)
+			r.EventRecorder.Eventf(&csr, corev1.EventTypeWarning, "RetryableError", "Failed to sign CertificateRequest, will retry: %s", err)
 			if didCustomConditionTransition {
 				// the reconciliation loop will be retriggered because of the added/ changed custom condition
-				return result, crStatusPatch, nil // done, apply patch
+				return result, csrStatusPatch, nil // done, apply patch
 			} else {
 				// We trigger a reconciliation here. Controller-runtime will use exponential backoff to requeue
 				// the request. We don't return an error here because we don't want controller-runtime to log an
@@ -338,28 +250,19 @@ func (r *CertificateRequestReconciler) reconcileStatusPatch(
 				// apiserver failure (see "unexpected get error" above). The ReconcileTotal labelRequeue metric
 				// can be used instead to get some estimate of the number of requeues.
 				result.Requeue = true
-				return result, crStatusPatch, nil // requeue with backoff, apply patch
+				return result, csrStatusPatch, nil // requeue with backoff, apply patch
 			}
 		}
 	}
 
-	crStatusPatch.Certificate = signedCertificate
-	conditions.SetCertificateRequestStatusCondition(
-		r.Clock,
-		cr.Status.Conditions,
-		&crStatusPatch.Conditions,
-		cmapi.CertificateRequestConditionReady,
-		cmmeta.ConditionTrue,
-		cmapi.CertificateRequestReasonIssued,
-		"issued",
-	)
+	csrStatusPatch.Certificate = signedCertificate
 
 	logger.V(1).Info("Successfully finished the reconciliation.")
-	r.EventRecorder.Eventf(&cr, corev1.EventTypeNormal, "Issued", "Succeeded signing the CertificateRequest")
-	return result, crStatusPatch, nil // done, apply patch
+	r.EventRecorder.Eventf(&csr, corev1.EventTypeNormal, "Issued", "Succeeded signing the CertificateRequest")
+	return result, csrStatusPatch, nil // done, apply patch
 }
 
-func (r *CertificateRequestReconciler) setIssuersGroupVersionKind(scheme *runtime.Scheme) error {
+func (r *CertificateSigningRequestReconciler) setIssuersGroupVersionKind(scheme *runtime.Scheme) error {
 	for _, issuerType := range r.allIssuerTypes() {
 		if err := kubeutil.SetGroupVersionKind(scheme, issuerType); err != nil {
 			return err
@@ -368,36 +271,59 @@ func (r *CertificateRequestReconciler) setIssuersGroupVersionKind(scheme *runtim
 	return nil
 }
 
-func (r *CertificateRequestReconciler) matchIssuerType(cr *cmapi.CertificateRequest) (v1alpha1.Issuer, types.NamespacedName) {
+// matchIssuerType returns the IssuerType and IssuerName that matches the
+// signerName of the CertificateSigningRequest. If no match is found, an error
+// is returned.
+// The signerName of the CertificateSigningRequest should be in the format
+// "<issuer-type-id>/<issuer-id>". The issuer-type-id is obtained from the
+// GetIssuerTypeIdentifier function of the IssuerType.
+// The issuer-id is "<namespace>.<name>" for an Issuer or "<name>" for a
+// ClusterIssuer resource.
+func (r *CertificateSigningRequestReconciler) matchIssuerType(csr *certificatesv1.CertificateSigningRequest) (v1alpha1.Issuer, types.NamespacedName, error) {
+	if csr == nil {
+		return nil, types.NamespacedName{}, fmt.Errorf("invalid signer name, should have format <issuer-type-id>/<issuer-id>")
+	}
+
+	split := strings.Split(csr.Spec.SignerName, "/")
+	if len(split) != 2 {
+		return nil, types.NamespacedName{}, fmt.Errorf("invalid signer name, should have format <issuer-type-id>/<issuer-id>: %q", csr.Spec.SignerName)
+	}
+
+	issuerTypeIdentifier := split[0]
+	issuerIdentifier := split[1]
+
 	// Search for matching issuer
 	for i, issuerType := range r.allIssuerTypes() {
 		// The namespaced issuers are located in the first part of the array.
 		isNamespaced := i < len(r.IssuerTypes)
 
-		gvk := issuerType.GetObjectKind().GroupVersionKind()
-
-		if (cr.Spec.IssuerRef.Group != gvk.Group) ||
-			(cr.Spec.IssuerRef.Kind != "" && cr.Spec.IssuerRef.Kind != gvk.Kind) {
+		if issuerTypeIdentifier != issuerType.GetIssuerTypeIdentifier() {
 			continue
 		}
 
-		namespace := ""
-		if isNamespaced {
-			namespace = cr.Namespace
+		issuerObject := issuerType.DeepCopyObject().(v1alpha1.Issuer)
+
+		issuerName := types.NamespacedName{
+			Name: issuerIdentifier,
 		}
 
-		issuerObject := issuerType.DeepCopyObject().(v1alpha1.Issuer)
-		issuerName := types.NamespacedName{
-			Name:      cr.Spec.IssuerRef.Name,
-			Namespace: namespace,
+		if isNamespaced {
+			split := strings.SplitN(issuerIdentifier, ".", 2)
+			if len(split) != 2 {
+				return nil, types.NamespacedName{}, fmt.Errorf("invalid issuer identifier, should have format %s/<namespace>.<name>: %q", issuerTypeIdentifier, csr.Spec.SignerName)
+			}
+
+			issuerName.Namespace = split[0]
+			issuerName.Name = split[1]
 		}
-		return issuerObject, issuerName
+
+		return issuerObject, issuerName, nil
 	}
 
-	return nil, types.NamespacedName{}
+	return nil, types.NamespacedName{}, fmt.Errorf("no issuer found for signer name: %q", csr.Spec.SignerName)
 }
 
-func (r *CertificateRequestReconciler) allIssuerTypes() []v1alpha1.Issuer {
+func (r *CertificateSigningRequestReconciler) allIssuerTypes() []v1alpha1.Issuer {
 	issuers := make([]v1alpha1.Issuer, 0, len(r.IssuerTypes)+len(r.ClusterIssuerTypes))
 	issuers = append(issuers, r.IssuerTypes...)
 	issuers = append(issuers, r.ClusterIssuerTypes...)
@@ -414,12 +340,12 @@ func (r *CertificateRequestReconciler) allIssuerTypes() []v1alpha1.Issuer {
 // when an Issuer / ClusterIssuer is created or when it changes. This ensures
 // that a CertificateRequest will be properly reconciled regardless of whether
 // the Issuer it references is created before or afterwards.
-func (r *CertificateRequestReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
-	if err := setupCertificateRequestReconcilerScheme(mgr.GetScheme()); err != nil {
+func (r *CertificateSigningRequestReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	if err := setupCertificateSigningRequestReconcilerScheme(mgr.GetScheme()); err != nil {
 		return err
 	}
 
-	crType := &cmapi.CertificateRequest{}
+	crType := &certificatesv1.CertificateSigningRequest{}
 	if err := kubeutil.SetGroupVersionKind(mgr.GetScheme(), crType); err != nil {
 		return err
 	}
@@ -438,7 +364,7 @@ func (r *CertificateRequestReconciler) SetupWithManager(ctx context.Context, mgr
 			// we only want to re-reconcile with backoff/ when a resource becomes available.
 			builder.WithPredicates(
 				predicate.ResourceVersionChangedPredicate{},
-				CertificateRequestPredicate{},
+				CertificateSigningRequestPredicate{},
 			),
 		)
 
@@ -470,12 +396,12 @@ func (r *CertificateRequestReconciler) SetupWithManager(ctx context.Context, mgr
 			mgr.GetLogger(),
 			mgr.GetScheme(),
 			mgr.GetCache(),
-			&cmapi.CertificateRequest{},
+			&certificatesv1.CertificateSigningRequest{},
 			func(rawObj client.Object) []string {
-				cr := rawObj.(*cmapi.CertificateRequest)
+				csr := rawObj.(*certificatesv1.CertificateSigningRequest)
 
-				issuerObject, issuerName := r.matchIssuerType(cr)
-				if issuerObject == nil || issuerObject.GetObjectKind().GroupVersionKind() != gvk {
+				issuerObject, issuerName, err := r.matchIssuerType(csr)
+				if err != nil || issuerObject.GetObjectKind().GroupVersionKind() != gvk {
 					return nil
 				}
 
@@ -507,6 +433,6 @@ func (r *CertificateRequestReconciler) SetupWithManager(ctx context.Context, mgr
 	return nil
 }
 
-func setupCertificateRequestReconcilerScheme(scheme *runtime.Scheme) error {
-	return cmapi.AddToScheme(scheme)
+func setupCertificateSigningRequestReconcilerScheme(scheme *runtime.Scheme) error {
+	return certificatesv1.AddToScheme(scheme)
 }

--- a/controllers/certificatesigningrequest_controller.go
+++ b/controllers/certificatesigningrequest_controller.go
@@ -277,8 +277,7 @@ func (r *CertificateSigningRequestReconciler) setIssuersGroupVersionKind(scheme 
 // The signerName of the CertificateSigningRequest should be in the format
 // "<issuer-type-id>/<issuer-id>". The issuer-type-id is obtained from the
 // GetIssuerTypeIdentifier function of the IssuerType.
-// The issuer-id is "<namespace>.<name>" for an Issuer or "<name>" for a
-// ClusterIssuer resource.
+// The issuer-id is "<name>" for a ClusterIssuer resource.
 func (r *CertificateSigningRequestReconciler) matchIssuerType(csr *certificatesv1.CertificateSigningRequest) (v1alpha1.Issuer, types.NamespacedName, error) {
 	if csr == nil {
 		return nil, types.NamespacedName{}, fmt.Errorf("invalid signer name, should have format <issuer-type-id>/<issuer-id>")
@@ -308,13 +307,7 @@ func (r *CertificateSigningRequestReconciler) matchIssuerType(csr *certificatesv
 		}
 
 		if isNamespaced {
-			split := strings.SplitN(issuerIdentifier, ".", 2)
-			if len(split) != 2 {
-				return nil, types.NamespacedName{}, fmt.Errorf("invalid issuer identifier, should have format %s/<namespace>.<name>: %q", issuerTypeIdentifier, csr.Spec.SignerName)
-			}
-
-			issuerName.Namespace = split[0]
-			issuerName.Name = split[1]
+			return nil, types.NamespacedName{}, fmt.Errorf("invalid SignerName, %q is a namespaced issuer type, namespaced issuers are not supported for Kubernetes CSRs", issuerTypeIdentifier)
 		}
 
 		return issuerObject, issuerName, nil

--- a/controllers/certificatesigningrequest_controller_test.go
+++ b/controllers/certificatesigningrequest_controller_test.go
@@ -29,6 +29,8 @@ import (
 	logrtesting "github.com/go-logr/logr/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -48,7 +50,7 @@ import (
 	"github.com/cert-manager/issuer-lib/internal/testsetups/simple/testutil"
 )
 
-func TestCertificateRequestReconcilerReconcile(t *testing.T) {
+func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 	t.Parallel()
 
 	fieldOwner := "test-certificate-request-reconciler-reconcile"
@@ -59,7 +61,7 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 		objects             []client.Object
 		validateError       *errormatch.Matcher
 		expectedResult      reconcile.Result
-		expectedStatusPatch *cmapi.CertificateRequestStatus
+		expectedStatusPatch *certificatesv1.CertificateSigningRequestStatus
 		expectedEvents      []string
 	}
 
@@ -98,28 +100,16 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 		),
 	)
 
-	cr1 := cmgen.CertificateRequest(
+	cr1 := cmgen.CertificateSigningRequest(
 		"cr1",
-		cmgen.SetCertificateRequestNamespace("ns1"),
-		cmgen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
-			Group: api.SchemeGroupVersion.Group,
-		}),
-		func(cr *cmapi.CertificateRequest) {
-			conditions.SetCertificateRequestStatusCondition(
+		cmgen.SetCertificateSigningRequestSignerName("simpleissuers.issuer.cert-manager.io/unknown-namespace.unknown-name"),
+		func(cr *certificatesv1.CertificateSigningRequest) {
+			conditions.SetCertificateSigningRequestStatusCondition(
 				fakeClock1,
 				cr.Status.Conditions,
 				&cr.Status.Conditions,
-				cmapi.CertificateRequestConditionReady,
-				cmmeta.ConditionUnknown,
-				v1alpha1.CertificateRequestConditionReasonInitializing,
-				fieldOwner+" has begun reconciling this CertificateRequest",
-			)
-			conditions.SetCertificateRequestStatusCondition(
-				fakeClock1,
-				cr.Status.Conditions,
-				&cr.Status.Conditions,
-				cmapi.CertificateRequestConditionApproved,
-				cmmeta.ConditionTrue,
+				certificatesv1.CertificateApproved,
+				v1.ConditionTrue,
 				"ApprovedReason",
 				"ApprovedMessage",
 			)
@@ -146,28 +136,28 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 		{
 			name: "ignore-unless-approved-or-denied",
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1, func(cr *cmapi.CertificateRequest) {
+				cmgen.CertificateSigningRequestFrom(cr1, func(cr *certificatesv1.CertificateSigningRequest) {
 					cr.Status.Conditions = nil
 				}),
 			},
 		},
 
-		// Ignore CertificateRequest with an unknown issuerRef group.
+		// Ignore CertificateRequest with an unknown SignerName group.
 		{
 			name: "issuer-ref-unknown-group",
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1, func(cr *cmapi.CertificateRequest) {
-					cr.Spec.IssuerRef.Group = "unknown-group"
+				cmgen.CertificateSigningRequestFrom(cr1, func(cr *certificatesv1.CertificateSigningRequest) {
+					cr.Spec.SignerName = "simpleclusterissuers.unknown-group/name"
 				}),
 			},
 		},
 
-		// Ignore CertificateRequest with an unknown issuerRef kind.
+		// Ignore CertificateRequest with an unknown SignerName kind.
 		{
 			name: "issuer-ref-unknown-kind",
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1, func(cr *cmapi.CertificateRequest) {
-					cr.Spec.IssuerRef.Kind = "unknown-kind"
+				cmgen.CertificateSigningRequestFrom(cr1, func(cr *certificatesv1.CertificateSigningRequest) {
+					cr.Spec.SignerName = "unknown-kind.issuer.cert-manager.io/name"
 				}),
 			},
 		},
@@ -176,12 +166,10 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 		{
 			name: "already-ready",
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1,
-					cmgen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
-						Type:   cmapi.CertificateRequestConditionReady,
-						Reason: cmapi.CertificateRequestReasonIssued,
-						Status: cmmeta.ConditionTrue,
-					}),
+				cmgen.CertificateSigningRequestFrom(cr1,
+					func(csr *certificatesv1.CertificateSigningRequest) {
+						csr.Status.Certificate = []byte("certificate")
+					},
 				),
 			},
 		},
@@ -190,11 +178,10 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 		{
 			name: "already-failed",
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1,
-					cmgen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
-						Type:   cmapi.CertificateRequestConditionReady,
-						Status: cmmeta.ConditionFalse,
-						Reason: cmapi.CertificateRequestReasonFailed,
+				cmgen.CertificateSigningRequestFrom(cr1,
+					cmgen.SetCertificateSigningRequestStatusCondition(certificatesv1.CertificateSigningRequestCondition{
+						Type:   certificatesv1.CertificateFailed,
+						Status: v1.ConditionTrue,
 					}),
 				),
 			},
@@ -204,62 +191,12 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 		{
 			name: "already-denied",
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1,
-					cmgen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
-						Type:   cmapi.CertificateRequestConditionReady,
-						Status: cmmeta.ConditionFalse,
-						Reason: cmapi.CertificateRequestReasonDenied,
+				cmgen.CertificateSigningRequestFrom(cr1,
+					cmgen.SetCertificateSigningRequestStatusCondition(certificatesv1.CertificateSigningRequestCondition{
+						Type:   certificatesv1.CertificateDenied,
+						Status: v1.ConditionTrue,
 					}),
 				),
-			},
-		},
-
-		// Initialize the CertificateRequest Ready condition if it is missing.
-		{
-			name: "initialize-ready-condition",
-			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1, func(cr *cmapi.CertificateRequest) {
-					removeCertificateRequestCondition(cr, cmapi.CertificateRequestConditionReady)
-				}),
-			},
-			expectedResult: reconcile.Result{},
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
-				Conditions: []cmapi.CertificateRequestCondition{
-					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionUnknown,
-						Reason:             v1alpha1.CertificateRequestConditionReasonInitializing,
-						Message:            fieldOwner + " has started reconciling this CertificateRequest",
-						LastTransitionTime: &fakeTimeObj2,
-					},
-				},
-			},
-		},
-
-		// If denied, set Ready condition status to false and reason to denied.
-		{
-			name: "set-ready-denied",
-			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1, cmgen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
-					Type:   cmapi.CertificateRequestConditionDenied,
-					Status: cmmeta.ConditionTrue,
-					Reason: "",
-				})),
-			},
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
-				Conditions: []cmapi.CertificateRequestCondition{
-					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionFalse,
-						Reason:             cmapi.CertificateRequestReasonDenied,
-						Message:            "The CertificateRequest was denied by an approval controller",
-						LastTransitionTime: &fakeTimeObj2,
-					},
-				},
-				FailureTime: &fakeTimeObj2,
-			},
-			expectedEvents: []string{
-				"Normal DetectedDenied Detected that the CR is denied, will update Ready condition",
 			},
 		},
 
@@ -267,21 +204,12 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 		{
 			name: "set-ready-pending-missing-issuer",
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1, func(cr *cmapi.CertificateRequest) {
-					cr.Spec.IssuerRef.Name = issuer1.Name
-					cr.Spec.IssuerRef.Kind = issuer1.Kind
+				cmgen.CertificateSigningRequestFrom(cr1, func(cr *certificatesv1.CertificateSigningRequest) {
+					cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
 				}),
 			},
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
-				Conditions: []cmapi.CertificateRequestCondition{
-					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionFalse,
-						Reason:             cmapi.CertificateRequestReasonPending,
-						Message:            "simpleissuers.testing.cert-manager.io \"issuer-1\" not found. Waiting for it to be created.",
-						LastTransitionTime: &fakeTimeObj2,
-					},
-				},
+			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: nil,
 			},
 			expectedEvents: []string{
 				"Normal WaitingForIssuerExist Waiting for the issuer to exist",
@@ -293,28 +221,17 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 		{
 			name: "set-ready-pending-issuer-has-no-ready-condition",
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1,
-					cmgen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
-						Name:  issuer1.Name,
-						Group: api.SchemeGroupVersion.Group,
-					}),
-				),
+				cmgen.CertificateSigningRequestFrom(cr1, func(cr *certificatesv1.CertificateSigningRequest) {
+					cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+				}),
 				testutil.SimpleIssuerFrom(issuer1,
 					func(si *api.SimpleIssuer) {
 						si.Status.Conditions = nil
 					},
 				),
 			},
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
-				Conditions: []cmapi.CertificateRequestCondition{
-					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionFalse,
-						Reason:             cmapi.CertificateRequestReasonPending,
-						Message:            "Issuer is not Ready yet. No ready condition found. Waiting for it to become ready.",
-						LastTransitionTime: &fakeTimeObj2,
-					},
-				},
+			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: nil,
 			},
 			expectedEvents: []string{
 				"Normal WaitingForIssuerReady Waiting for the issuer to become ready",
@@ -325,12 +242,9 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 		{
 			name: "set-ready-pending-issuer-is-not-ready",
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1,
-					cmgen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
-						Name:  issuer1.Name,
-						Group: api.SchemeGroupVersion.Group,
-					}),
-				),
+				cmgen.CertificateSigningRequestFrom(cr1, func(cr *certificatesv1.CertificateSigningRequest) {
+					cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+				}),
 				testutil.SimpleIssuerFrom(issuer1,
 					testutil.SetSimpleIssuerStatusCondition(
 						fakeClock1,
@@ -341,16 +255,8 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 					),
 				),
 			},
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
-				Conditions: []cmapi.CertificateRequestCondition{
-					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionFalse,
-						Reason:             cmapi.CertificateRequestReasonPending,
-						Message:            "Issuer is not Ready yet. Current ready condition is \"[REASON]\": [MESSAGE]. Waiting for it to become ready.",
-						LastTransitionTime: &fakeTimeObj2,
-					},
-				},
+			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: nil,
 			},
 			expectedEvents: []string{
 				"Normal WaitingForIssuerReady Waiting for the issuer to become ready",
@@ -362,26 +268,15 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 		{
 			name: "set-ready-pending-issuer-ready-outdated",
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1,
-					cmgen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
-						Name:  issuer1.Name,
-						Group: api.SchemeGroupVersion.Group,
-					}),
-				),
+				cmgen.CertificateSigningRequestFrom(cr1, func(cr *certificatesv1.CertificateSigningRequest) {
+					cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+				}),
 				testutil.SimpleIssuerFrom(issuer1,
 					testutil.SetSimpleIssuerGeneration(issuer1.Generation+1),
 				),
 			},
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
-				Conditions: []cmapi.CertificateRequestCondition{
-					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionFalse,
-						Reason:             cmapi.CertificateRequestReasonPending,
-						Message:            "Issuer is not Ready yet. Current ready condition is outdated. Waiting for it to become ready.",
-						LastTransitionTime: &fakeTimeObj2,
-					},
-				},
+			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: nil,
 			},
 			expectedEvents: []string{
 				"Normal WaitingForIssuerReady Waiting for the issuer to become ready",
@@ -396,28 +291,27 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 				return nil, fmt.Errorf("a specific error")
 			},
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1,
-					cmgen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
-						Name:  issuer1.Name,
-						Group: api.SchemeGroupVersion.Group,
-					}),
-					func(cr *cmapi.CertificateRequest) {
+				cmgen.CertificateSigningRequestFrom(cr1,
+					func(cr *certificatesv1.CertificateSigningRequest) {
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+					},
+					func(cr *certificatesv1.CertificateSigningRequest) {
 						cr.CreationTimestamp = metav1.NewTime(fakeTimeObj2.Add(-2 * time.Minute))
 					},
 				),
 				testutil.SimpleIssuerFrom(issuer1),
 			},
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
-				Conditions: []cmapi.CertificateRequestCondition{
+			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: []certificatesv1.CertificateSigningRequestCondition{
 					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionFalse,
+						Type:               certificatesv1.CertificateFailed,
+						Status:             v1.ConditionTrue,
 						Reason:             cmapi.CertificateRequestReasonFailed,
 						Message:            "CertificateRequest has failed permanently: a specific error",
-						LastTransitionTime: &fakeTimeObj2,
+						LastTransitionTime: fakeTimeObj2,
+						LastUpdateTime:     fakeTimeObj2,
 					},
 				},
-				FailureTime: &fakeTimeObj2,
 			},
 			expectedEvents: []string{
 				"Warning PermanentError Failed permanently to sign CertificateRequest: a specific error",
@@ -432,12 +326,11 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 				return nil, signer.PendingError{Err: fmt.Errorf("pending error")}
 			},
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1,
-					cmgen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
-						Name:  issuer1.Name,
-						Group: api.SchemeGroupVersion.Group,
-					}),
-					func(cr *cmapi.CertificateRequest) {
+				cmgen.CertificateSigningRequestFrom(cr1,
+					func(cr *certificatesv1.CertificateSigningRequest) {
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+					},
+					func(cr *certificatesv1.CertificateSigningRequest) {
 						cr.CreationTimestamp = metav1.NewTime(fakeTimeObj2.Add(-2 * time.Minute))
 					},
 				),
@@ -448,16 +341,8 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 			expectedResult: reconcile.Result{
 				Requeue: true,
 			},
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
-				Conditions: []cmapi.CertificateRequestCondition{
-					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionFalse,
-						Reason:             cmapi.CertificateRequestReasonPending,
-						Message:            "CertificateRequest is not ready yet: pending error",
-						LastTransitionTime: &fakeTimeObj2,
-					},
-				},
+			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: nil,
 			},
 			expectedEvents: []string{
 				"Warning RetryableError Failed to sign CertificateRequest, will retry: pending error",
@@ -481,35 +366,28 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 				}
 			},
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1,
-					func(cr *cmapi.CertificateRequest) {
+				cmgen.CertificateSigningRequestFrom(cr1,
+					func(cr *certificatesv1.CertificateSigningRequest) {
 						cr.CreationTimestamp = fakeTimeObj2
 					},
-					cmgen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
-						Name:  issuer1.Name,
-						Group: api.SchemeGroupVersion.Group,
-					}),
+					func(cr *certificatesv1.CertificateSigningRequest) {
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+					},
 				),
 				testutil.SimpleIssuerFrom(issuer1),
 			},
 			// no error should be returned because the reconciliation should be triggered
 			// when the custom condition is added
 			validateError: errormatch.NoError(),
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
-				Conditions: []cmapi.CertificateRequestCondition{
+			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: []certificatesv1.CertificateSigningRequestCondition{
 					{
 						Type:               "[condition type]",
-						Status:             cmmeta.ConditionTrue,
+						Status:             v1.ConditionTrue,
 						Reason:             "[reason]",
 						Message:            "test error",
-						LastTransitionTime: &fakeTimeObj2,
-					},
-					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionFalse,
-						Reason:             cmapi.CertificateRequestReasonPending,
-						Message:            "CertificateRequest is not ready yet: test error",
-						LastTransitionTime: &fakeTimeObj2,
+						LastTransitionTime: fakeTimeObj2,
+						LastUpdateTime:     fakeTimeObj2,
 					},
 				},
 			},
@@ -535,20 +413,20 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 				}
 			},
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1,
-					func(cr *cmapi.CertificateRequest) {
+				cmgen.CertificateSigningRequestFrom(cr1,
+					func(cr *certificatesv1.CertificateSigningRequest) {
 						cr.CreationTimestamp = fakeTimeObj2
 					},
-					cmgen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
-						Name:  issuer1.Name,
-						Group: api.SchemeGroupVersion.Group,
-					}),
-					cmgen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+					func(cr *certificatesv1.CertificateSigningRequest) {
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+					},
+					cmgen.SetCertificateSigningRequestStatusCondition(certificatesv1.CertificateSigningRequestCondition{
 						Type:               "[condition type]",
-						Status:             cmmeta.ConditionTrue,
+						Status:             v1.ConditionTrue,
 						Reason:             "[reason]",
 						Message:            "test error",
-						LastTransitionTime: &fakeTimeObj2,
+						LastTransitionTime: fakeTimeObj2,
+						LastUpdateTime:     fakeTimeObj2,
 					}),
 				),
 				testutil.SimpleIssuerFrom(issuer1),
@@ -558,21 +436,15 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 			expectedResult: reconcile.Result{
 				Requeue: true,
 			},
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
-				Conditions: []cmapi.CertificateRequestCondition{
+			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: []certificatesv1.CertificateSigningRequestCondition{
 					{
 						Type:               "[condition type]",
-						Status:             cmmeta.ConditionTrue,
+						Status:             v1.ConditionTrue,
 						Reason:             "[reason]",
 						Message:            "test error2",
-						LastTransitionTime: &fakeTimeObj2,
-					},
-					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionFalse,
-						Reason:             cmapi.CertificateRequestReasonPending,
-						Message:            "CertificateRequest is not ready yet: test error2",
-						LastTransitionTime: &fakeTimeObj2,
+						LastTransitionTime: fakeTimeObj2,
+						LastUpdateTime:     fakeTimeObj2,
 					},
 				},
 			},
@@ -598,12 +470,11 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 				}
 			},
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1,
-					cmgen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
-						Name:  issuer1.Name,
-						Group: api.SchemeGroupVersion.Group,
-					}),
-					func(cr *cmapi.CertificateRequest) {
+				cmgen.CertificateSigningRequestFrom(cr1,
+					func(cr *certificatesv1.CertificateSigningRequest) {
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+					},
+					func(cr *certificatesv1.CertificateSigningRequest) {
 						cr.CreationTimestamp = metav1.NewTime(fakeTimeObj2.Add(-2 * time.Minute))
 					},
 				),
@@ -612,24 +483,25 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 			// no error should be returned because the reconciliation should be triggered when the
 			// custom condition is added
 			validateError: errormatch.NoError(),
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
-				Conditions: []cmapi.CertificateRequestCondition{
+			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: []certificatesv1.CertificateSigningRequestCondition{
 					{
 						Type:               "[condition type]",
-						Status:             cmmeta.ConditionTrue,
+						Status:             v1.ConditionTrue,
 						Reason:             "[reason]",
 						Message:            "test error",
-						LastTransitionTime: &fakeTimeObj2,
+						LastTransitionTime: fakeTimeObj2,
+						LastUpdateTime:     fakeTimeObj2,
 					},
 					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionFalse,
+						Type:               certificatesv1.CertificateFailed,
+						Status:             v1.ConditionTrue,
 						Reason:             cmapi.CertificateRequestReasonFailed,
 						Message:            "CertificateRequest has failed permanently: test error",
-						LastTransitionTime: &fakeTimeObj2,
+						LastTransitionTime: fakeTimeObj2,
+						LastUpdateTime:     fakeTimeObj2,
 					},
 				},
-				FailureTime: &fakeTimeObj2,
 			},
 			expectedEvents: []string{
 				"Warning PermanentError Failed permanently to sign CertificateRequest: test error",
@@ -653,44 +525,45 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 				}
 			},
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1,
-					cmgen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
-						Name:  issuer1.Name,
-						Group: api.SchemeGroupVersion.Group,
-					}),
-					func(cr *cmapi.CertificateRequest) {
+				cmgen.CertificateSigningRequestFrom(cr1,
+					func(cr *certificatesv1.CertificateSigningRequest) {
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+					},
+					func(cr *certificatesv1.CertificateSigningRequest) {
 						cr.CreationTimestamp = metav1.NewTime(fakeTimeObj2.Add(-2 * time.Minute))
 					},
-					cmgen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+					cmgen.SetCertificateSigningRequestStatusCondition(certificatesv1.CertificateSigningRequestCondition{
 						Type:               "[condition type]",
-						Status:             cmmeta.ConditionTrue,
+						Status:             v1.ConditionTrue,
 						Reason:             "[reason]",
 						Message:            "test error",
-						LastTransitionTime: &fakeTimeObj1,
+						LastTransitionTime: fakeTimeObj1,
+						LastUpdateTime:     fakeTimeObj1,
 					}),
 				),
 				testutil.SimpleIssuerFrom(issuer1),
 			},
 			// since we got into a permanent failure state, we should not return an error
 			validateError: errormatch.NoError(),
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
-				Conditions: []cmapi.CertificateRequestCondition{
+			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: []certificatesv1.CertificateSigningRequestCondition{
 					{
 						Type:               "[condition type]",
-						Status:             cmmeta.ConditionTrue,
+						Status:             v1.ConditionTrue,
 						Reason:             "[reason]",
 						Message:            "test error2",
-						LastTransitionTime: &fakeTimeObj1, // since the status is not updated, the LastTransitionTime is not updated either
+						LastTransitionTime: fakeTimeObj1, // since the status is not updated, the LastTransitionTime is not updated either
+						LastUpdateTime:     fakeTimeObj2,
 					},
 					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionFalse,
+						Type:               certificatesv1.CertificateFailed,
+						Status:             v1.ConditionTrue,
 						Reason:             cmapi.CertificateRequestReasonFailed,
 						Message:            "CertificateRequest has failed permanently: test error2",
-						LastTransitionTime: &fakeTimeObj2,
+						LastTransitionTime: fakeTimeObj2,
+						LastUpdateTime:     fakeTimeObj2,
 					},
 				},
-				FailureTime: &fakeTimeObj2,
 			},
 			expectedEvents: []string{
 				"Warning PermanentError Failed permanently to sign CertificateRequest: test error2",
@@ -713,12 +586,11 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 				}
 			},
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1,
-					cmgen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
-						Name:  issuer1.Name,
-						Group: api.SchemeGroupVersion.Group,
-					}),
-					func(cr *cmapi.CertificateRequest) {
+				cmgen.CertificateSigningRequestFrom(cr1,
+					func(cr *certificatesv1.CertificateSigningRequest) {
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+					},
+					func(cr *certificatesv1.CertificateSigningRequest) {
 						cr.CreationTimestamp = metav1.NewTime(fakeTimeObj2.Add(-2 * time.Minute))
 					},
 				),
@@ -727,21 +599,15 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 			// no error should be returned because the reconciliation should be triggered
 			// when the custom condition is added
 			validateError: errormatch.NoError(),
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
-				Conditions: []cmapi.CertificateRequestCondition{
+			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: []certificatesv1.CertificateSigningRequestCondition{
 					{
 						Type:               "[condition type]",
-						Status:             cmmeta.ConditionTrue,
+						Status:             v1.ConditionTrue,
 						Reason:             "[reason]",
 						Message:            "test error",
-						LastTransitionTime: &fakeTimeObj2,
-					},
-					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionFalse,
-						Reason:             cmapi.CertificateRequestReasonPending,
-						Message:            "CertificateRequest is not ready yet: test error",
-						LastTransitionTime: &fakeTimeObj2,
+						LastTransitionTime: fakeTimeObj2,
+						LastUpdateTime:     fakeTimeObj2,
 					},
 				},
 			},
@@ -766,35 +632,35 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 				}
 			},
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1,
-					cmgen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
-						Name:  issuer1.Name,
-						Group: api.SchemeGroupVersion.Group,
-					}),
+				cmgen.CertificateSigningRequestFrom(cr1,
+					func(cr *certificatesv1.CertificateSigningRequest) {
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+					},
 				),
 				testutil.SimpleIssuerFrom(issuer1),
 			},
 			// no error should be returned because we are in a permanent failure state no further
 			// retries should be made
 			validateError: errormatch.NoError(),
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
-				Conditions: []cmapi.CertificateRequestCondition{
+			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: []certificatesv1.CertificateSigningRequestCondition{
 					{
 						Type:               "[condition type]",
-						Status:             cmmeta.ConditionTrue,
+						Status:             v1.ConditionTrue,
 						Reason:             "[reason]",
 						Message:            "test error",
-						LastTransitionTime: &fakeTimeObj2,
+						LastTransitionTime: fakeTimeObj2,
+						LastUpdateTime:     fakeTimeObj2,
 					},
 					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionFalse,
+						Type:               certificatesv1.CertificateFailed,
+						Status:             v1.ConditionTrue,
 						Reason:             cmapi.CertificateRequestReasonFailed,
 						Message:            "CertificateRequest has failed permanently: test error",
-						LastTransitionTime: &fakeTimeObj2,
+						LastTransitionTime: fakeTimeObj2,
+						LastUpdateTime:     fakeTimeObj2,
 					},
 				},
-				FailureTime: &fakeTimeObj2,
 			},
 			expectedEvents: []string{
 				"Warning PermanentError Failed permanently to sign CertificateRequest: test error",
@@ -808,25 +674,24 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 				return nil, signer.PermanentError{Err: fmt.Errorf("a specific error")}
 			},
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1,
-					cmgen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
-						Name:  issuer1.Name,
-						Group: api.SchemeGroupVersion.Group,
-					}),
+				cmgen.CertificateSigningRequestFrom(cr1,
+					func(cr *certificatesv1.CertificateSigningRequest) {
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+					},
 				),
 				testutil.SimpleIssuerFrom(issuer1),
 			},
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
-				Conditions: []cmapi.CertificateRequestCondition{
+			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: []certificatesv1.CertificateSigningRequestCondition{
 					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionFalse,
+						Type:               certificatesv1.CertificateFailed,
+						Status:             v1.ConditionTrue,
 						Reason:             cmapi.CertificateRequestReasonFailed,
 						Message:            "CertificateRequest has failed permanently: a specific error",
-						LastTransitionTime: &fakeTimeObj2,
+						LastTransitionTime: fakeTimeObj2,
+						LastUpdateTime:     fakeTimeObj2,
 					},
 				},
-				FailureTime: &fakeTimeObj2,
 			},
 			expectedEvents: []string{
 				"Warning PermanentError Failed permanently to sign CertificateRequest: a specific error",
@@ -841,13 +706,12 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 				return nil, errors.New("waiting for approval")
 			},
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1,
-					func(cr *cmapi.CertificateRequest) {
-						cr.CreationTimestamp = fakeTimeObj2
+				cmgen.CertificateSigningRequestFrom(cr1,
+					func(cr *certificatesv1.CertificateSigningRequest) {
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
 					},
-					func(cr *cmapi.CertificateRequest) {
-						cr.Spec.IssuerRef.Name = issuer1.Name
-						cr.Spec.IssuerRef.Kind = issuer1.Kind
+					func(cr *certificatesv1.CertificateSigningRequest) {
+						cr.CreationTimestamp = fakeTimeObj2
 					},
 				),
 				testutil.SimpleIssuerFrom(issuer1),
@@ -857,16 +721,8 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 			expectedResult: reconcile.Result{
 				Requeue: true,
 			},
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
-				Conditions: []cmapi.CertificateRequestCondition{
-					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionFalse,
-						Reason:             cmapi.CertificateRequestReasonPending,
-						Message:            "CertificateRequest is not ready yet: waiting for approval",
-						LastTransitionTime: &fakeTimeObj2,
-					},
-				},
+			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: nil,
 			},
 			expectedEvents: []string{
 				"Warning RetryableError Failed to sign CertificateRequest, will retry: waiting for approval",
@@ -877,23 +733,14 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 			name: "success-issuer",
 			sign: successSigner("a-signed-certificate"),
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1, func(cr *cmapi.CertificateRequest) {
-					cr.Spec.IssuerRef.Name = issuer1.Name
-					cr.Spec.IssuerRef.Kind = issuer1.Kind
+				cmgen.CertificateSigningRequestFrom(cr1, func(cr *certificatesv1.CertificateSigningRequest) {
+					cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
 				}),
 				testutil.SimpleIssuerFrom(issuer1),
 			},
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
+			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
 				Certificate: []byte("a-signed-certificate"),
-				Conditions: []cmapi.CertificateRequestCondition{
-					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionTrue,
-						Reason:             cmapi.CertificateRequestReasonIssued,
-						Message:            "issued",
-						LastTransitionTime: &fakeTimeObj2,
-					},
-				},
+				Conditions:  nil,
 			},
 			expectedEvents: []string{
 				"Normal Issued Succeeded signing the CertificateRequest",
@@ -904,23 +751,14 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 			name: "success-clusterissuer",
 			sign: successSigner("a-signed-certificate"),
 			objects: []client.Object{
-				cmgen.CertificateRequestFrom(cr1, func(cr *cmapi.CertificateRequest) {
-					cr.Spec.IssuerRef.Name = clusterIssuer1.Name
-					cr.Spec.IssuerRef.Kind = clusterIssuer1.Kind
+				cmgen.CertificateSigningRequestFrom(cr1, func(cr *certificatesv1.CertificateSigningRequest) {
+					cr.Spec.SignerName = fmt.Sprintf("%s/%s", clusterIssuer1.GetIssuerTypeIdentifier(), clusterIssuer1.Name)
 				}),
 				testutil.SimpleClusterIssuerFrom(clusterIssuer1),
 			},
-			expectedStatusPatch: &cmapi.CertificateRequestStatus{
+			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
 				Certificate: []byte("a-signed-certificate"),
-				Conditions: []cmapi.CertificateRequestCondition{
-					{
-						Type:               cmapi.CertificateRequestConditionReady,
-						Status:             cmmeta.ConditionTrue,
-						Reason:             cmapi.CertificateRequestReasonIssued,
-						Message:            "issued",
-						LastTransitionTime: &fakeTimeObj2,
-					},
-				},
+				Conditions:  nil,
 			},
 			expectedEvents: []string{
 				"Normal Issued Succeeded signing the CertificateRequest",
@@ -934,7 +772,7 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 			t.Parallel()
 
 			scheme := runtime.NewScheme()
-			require.NoError(t, setupCertificateRequestReconcilerScheme(scheme))
+			require.NoError(t, setupCertificateSigningRequestReconcilerScheme(scheme))
 			require.NoError(t, api.AddToScheme(scheme))
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -948,14 +786,14 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 				},
 			}
 
-			var crBefore cmapi.CertificateRequest
+			var crBefore certificatesv1.CertificateSigningRequest
 			err := fakeClient.Get(context.TODO(), req.NamespacedName, &crBefore)
 			require.NoError(t, client.IgnoreNotFound(err), "unexpected error from fake client")
 
 			logger := logrtesting.NewTestLoggerWithOptions(t, logrtesting.Options{LogTimestamp: true, Verbosity: 10})
 			fakeRecorder := record.NewFakeRecorder(100)
 
-			controller := CertificateRequestReconciler{
+			controller := CertificateSigningRequestReconciler{
 				IssuerTypes:        []v1alpha1.Issuer{&api.SimpleIssuer{}},
 				ClusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleClusterIssuer{}},
 				FieldOwner:         fieldOwner,
@@ -986,24 +824,7 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 	}
 }
 
-func chanToSlice(ch <-chan string) []string {
-	out := make([]string, 0, len(ch))
-	for i := 0; i < len(ch); i++ {
-		out = append(out, <-ch)
-	}
-	return out
-}
-
-func removeCertificateRequestCondition(cr *cmapi.CertificateRequest, conditionType cmapi.CertificateRequestConditionType) {
-	for i, cond := range cr.Status.Conditions {
-		if cond.Type == conditionType {
-			cr.Status.Conditions = append(cr.Status.Conditions[:i], cr.Status.Conditions[i+1:]...)
-			return
-		}
-	}
-}
-
-func TestCertificateRequestMatchIssuerType(t *testing.T) {
+func TestCertificateSigningRequestMatchIssuerType(t *testing.T) {
 	t.Parallel()
 
 	type testcase struct {
@@ -1011,23 +832,17 @@ func TestCertificateRequestMatchIssuerType(t *testing.T) {
 
 		issuerTypes        []v1alpha1.Issuer
 		clusterIssuerTypes []v1alpha1.Issuer
-		cr                 *cmapi.CertificateRequest
+		csr                *certificatesv1.CertificateSigningRequest
 
 		expectedIssuerType v1alpha1.Issuer
 		expectedIssuerName types.NamespacedName
+		expectedError      *errormatch.Matcher
 	}
 
-	createCr := func(name string, namespace string, kind string, group string) *cmapi.CertificateRequest {
-		return &cmapi.CertificateRequest{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
-			},
-			Spec: cmapi.CertificateRequestSpec{
-				IssuerRef: cmmeta.ObjectReference{
-					Name:  name,
-					Kind:  kind,
-					Group: group,
-				},
+	createCsr := func(signerName string) *certificatesv1.CertificateSigningRequest {
+		return &certificatesv1.CertificateSigningRequest{
+			Spec: certificatesv1.CertificateSigningRequestSpec{
+				SignerName: signerName,
 			},
 		}
 	}
@@ -1037,25 +852,37 @@ func TestCertificateRequestMatchIssuerType(t *testing.T) {
 			name:               "empty",
 			issuerTypes:        nil,
 			clusterIssuerTypes: nil,
-			cr:                 nil,
+			csr:                nil,
 
 			expectedIssuerType: nil,
 			expectedIssuerName: types.NamespacedName{},
+			expectedError:      errormatch.ErrorContains("invalid signer name, should have format <issuer-type-id>/<issuer-id>"),
 		},
 		{
-			name:               "no issuers",
+			name:               "invalid signer name format",
 			issuerTypes:        nil,
 			clusterIssuerTypes: nil,
-			cr:                 createCr("name", "namespace", "", "test"),
+			csr:                createCsr("aaaaaa"),
 
 			expectedIssuerType: nil,
 			expectedIssuerName: types.NamespacedName{},
+			expectedError:      errormatch.ErrorContains("invalid signer name, should have format <issuer-type-id>/<issuer-id>: \"aaaaaa\""),
+		},
+		{
+			name:               "unknown issuer type identifier",
+			issuerTypes:        []v1alpha1.Issuer{&api.SimpleIssuer{}},
+			clusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleClusterIssuer{}},
+			csr:                createCsr("aaaaa.issuer.cert-manager.io/namespace.name"),
+
+			expectedIssuerType: nil,
+			expectedIssuerName: types.NamespacedName{},
+			expectedError:      errormatch.ErrorContains("no issuer found for signer name: \"aaaaa.issuer.cert-manager.io/namespace.name\""),
 		},
 		{
 			name:               "match issuer",
 			issuerTypes:        []v1alpha1.Issuer{&api.SimpleIssuer{}},
 			clusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleClusterIssuer{}},
-			cr:                 createCr("name", "namespace", "SimpleIssuer", "testing.cert-manager.io"),
+			csr:                createCsr("simpleissuers.issuer.cert-manager.io/namespace.name"),
 
 			expectedIssuerType: &api.SimpleIssuer{},
 			expectedIssuerName: types.NamespacedName{Name: "name", Namespace: "namespace"},
@@ -1064,37 +891,65 @@ func TestCertificateRequestMatchIssuerType(t *testing.T) {
 			name:               "match cluster issuer",
 			issuerTypes:        []v1alpha1.Issuer{&api.SimpleIssuer{}},
 			clusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleClusterIssuer{}},
-			cr:                 createCr("name", "namespace", "SimpleClusterIssuer", "testing.cert-manager.io"),
+			csr:                createCsr("simpleclusterissuers.issuer.cert-manager.io/name"),
 
 			expectedIssuerType: &api.SimpleClusterIssuer{},
 			expectedIssuerName: types.NamespacedName{Name: "name"},
 		},
 		{
-			name:               "select kind if empty",
-			issuerTypes:        []v1alpha1.Issuer{},
+			name:               "issuer with dot in name",
+			issuerTypes:        []v1alpha1.Issuer{&api.SimpleIssuer{}},
 			clusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleClusterIssuer{}},
-			cr:                 createCr("name", "namespace", "", "testing.cert-manager.io"),
+			csr:                createCsr("simpleissuers.issuer.cert-manager.io/namespace.name.test"),
+
+			expectedIssuerType: &api.SimpleIssuer{},
+			expectedIssuerName: types.NamespacedName{Namespace: "namespace", Name: "name.test"},
+		},
+		{
+			name:               "issuer with empty namespace",
+			issuerTypes:        []v1alpha1.Issuer{&api.SimpleIssuer{}},
+			clusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleClusterIssuer{}},
+			csr:                createCsr("simpleissuers.issuer.cert-manager.io/.name.test"),
+
+			expectedIssuerType: &api.SimpleIssuer{},
+			expectedIssuerName: types.NamespacedName{Namespace: "", Name: "name.test"},
+		},
+		{
+			name:               "issuer without dot in ID",
+			issuerTypes:        []v1alpha1.Issuer{&api.SimpleIssuer{}},
+			clusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleClusterIssuer{}},
+			csr:                createCsr("simpleissuers.issuer.cert-manager.io/test"),
+
+			expectedIssuerType: nil,
+			expectedIssuerName: types.NamespacedName{},
+			expectedError:      errormatch.ErrorContains("invalid issuer identifier, should have format simpleissuers.issuer.cert-manager.io/<namespace>.<name>: \"simpleissuers.issuer.cert-manager.io/test\""),
+		},
+		{
+			name:               "issuer with empty name",
+			issuerTypes:        []v1alpha1.Issuer{&api.SimpleIssuer{}},
+			clusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleClusterIssuer{}},
+			csr:                createCsr("simpleissuers.issuer.cert-manager.io/namespace."),
+
+			expectedIssuerType: &api.SimpleIssuer{},
+			expectedIssuerName: types.NamespacedName{Namespace: "namespace", Name: ""},
+		},
+		{
+			name:               "cluster issuer with dot in name",
+			issuerTypes:        []v1alpha1.Issuer{&api.SimpleIssuer{}},
+			clusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleClusterIssuer{}},
+			csr:                createCsr("simpleclusterissuers.issuer.cert-manager.io/name.test"),
 
 			expectedIssuerType: &api.SimpleClusterIssuer{},
-			expectedIssuerName: types.NamespacedName{Name: "name"},
+			expectedIssuerName: types.NamespacedName{Name: "name.test"},
 		},
 		{
-			name:               "prefer issuer over cluster issuer (v1)",
+			name:               "cluster issuer with empty name",
 			issuerTypes:        []v1alpha1.Issuer{&api.SimpleIssuer{}},
 			clusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleClusterIssuer{}},
-			cr:                 createCr("name", "namespace", "", "testing.cert-manager.io"),
+			csr:                createCsr("simpleclusterissuers.issuer.cert-manager.io/"),
 
-			expectedIssuerType: &api.SimpleIssuer{},
-			expectedIssuerName: types.NamespacedName{Name: "name", Namespace: "namespace"},
-		},
-		{
-			name:               "prefer issuer over cluster issuer (v2)",
-			issuerTypes:        []v1alpha1.Issuer{&api.SimpleIssuer{}},
-			clusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleIssuer{}},
-			cr:                 createCr("name", "namespace", "", "testing.cert-manager.io"),
-
-			expectedIssuerType: &api.SimpleIssuer{},
-			expectedIssuerName: types.NamespacedName{Name: "name", Namespace: "namespace"},
+			expectedIssuerType: &api.SimpleClusterIssuer{},
+			expectedIssuerName: types.NamespacedName{Name: ""},
 		},
 	}
 
@@ -1106,14 +961,14 @@ func TestCertificateRequestMatchIssuerType(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			crr := &CertificateRequestReconciler{
+			crr := &CertificateSigningRequestReconciler{
 				IssuerTypes:        tc.issuerTypes,
 				ClusterIssuerTypes: tc.clusterIssuerTypes,
 			}
 
 			require.NoError(t, crr.setIssuersGroupVersionKind(scheme))
 
-			issuerType, issuerName := crr.matchIssuerType(tc.cr)
+			issuerType, issuerName, err := crr.matchIssuerType(tc.csr)
 
 			if tc.expectedIssuerType != nil {
 				require.NoError(t, kubeutil.SetGroupVersionKind(scheme, tc.expectedIssuerType))
@@ -1121,6 +976,9 @@ func TestCertificateRequestMatchIssuerType(t *testing.T) {
 
 			assert.Equal(t, tc.expectedIssuerType, issuerType)
 			assert.Equal(t, tc.expectedIssuerName, issuerName)
+			if !ptr.Default(tc.expectedError, *errormatch.NoError())(t, err) {
+				t.Fail()
+			}
 		})
 	}
 }

--- a/controllers/certificatesigningrequest_controller_test.go
+++ b/controllers/certificatesigningrequest_controller_test.go
@@ -205,7 +205,7 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 			name: "set-ready-pending-missing-issuer",
 			objects: []client.Object{
 				cmgen.CertificateSigningRequestFrom(cr1, func(cr *certificatesv1.CertificateSigningRequest) {
-					cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+					cr.Spec.SignerName = fmt.Sprintf("%s/%s", clusterIssuer1.GetIssuerTypeIdentifier(), clusterIssuer1.Name)
 				}),
 			},
 			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
@@ -222,10 +222,10 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 			name: "set-ready-pending-issuer-has-no-ready-condition",
 			objects: []client.Object{
 				cmgen.CertificateSigningRequestFrom(cr1, func(cr *certificatesv1.CertificateSigningRequest) {
-					cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+					cr.Spec.SignerName = fmt.Sprintf("%s/%s", clusterIssuer1.GetIssuerTypeIdentifier(), clusterIssuer1.Name)
 				}),
-				testutil.SimpleIssuerFrom(issuer1,
-					func(si *api.SimpleIssuer) {
+				testutil.SimpleClusterIssuerFrom(clusterIssuer1,
+					func(si *api.SimpleClusterIssuer) {
 						si.Status.Conditions = nil
 					},
 				),
@@ -243,10 +243,10 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 			name: "set-ready-pending-issuer-is-not-ready",
 			objects: []client.Object{
 				cmgen.CertificateSigningRequestFrom(cr1, func(cr *certificatesv1.CertificateSigningRequest) {
-					cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+					cr.Spec.SignerName = fmt.Sprintf("%s/%s", clusterIssuer1.GetIssuerTypeIdentifier(), clusterIssuer1.Name)
 				}),
-				testutil.SimpleIssuerFrom(issuer1,
-					testutil.SetSimpleIssuerStatusCondition(
+				testutil.SimpleClusterIssuerFrom(clusterIssuer1,
+					testutil.SetSimpleClusterIssuerStatusCondition(
 						fakeClock1,
 						cmapi.IssuerConditionReady,
 						cmmeta.ConditionFalse,
@@ -269,10 +269,10 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 			name: "set-ready-pending-issuer-ready-outdated",
 			objects: []client.Object{
 				cmgen.CertificateSigningRequestFrom(cr1, func(cr *certificatesv1.CertificateSigningRequest) {
-					cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+					cr.Spec.SignerName = fmt.Sprintf("%s/%s", clusterIssuer1.GetIssuerTypeIdentifier(), clusterIssuer1.Name)
 				}),
-				testutil.SimpleIssuerFrom(issuer1,
-					testutil.SetSimpleIssuerGeneration(issuer1.Generation+1),
+				testutil.SimpleClusterIssuerFrom(clusterIssuer1,
+					testutil.SetSimpleClusterIssuerGeneration(issuer1.Generation+1),
 				),
 			},
 			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
@@ -293,13 +293,13 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 			objects: []client.Object{
 				cmgen.CertificateSigningRequestFrom(cr1,
 					func(cr *certificatesv1.CertificateSigningRequest) {
-						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s", clusterIssuer1.GetIssuerTypeIdentifier(), clusterIssuer1.Name)
 					},
 					func(cr *certificatesv1.CertificateSigningRequest) {
 						cr.CreationTimestamp = metav1.NewTime(fakeTimeObj2.Add(-2 * time.Minute))
 					},
 				),
-				testutil.SimpleIssuerFrom(issuer1),
+				testutil.SimpleClusterIssuerFrom(clusterIssuer1),
 			},
 			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
 				Conditions: []certificatesv1.CertificateSigningRequestCondition{
@@ -328,13 +328,13 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 			objects: []client.Object{
 				cmgen.CertificateSigningRequestFrom(cr1,
 					func(cr *certificatesv1.CertificateSigningRequest) {
-						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s", clusterIssuer1.GetIssuerTypeIdentifier(), clusterIssuer1.Name)
 					},
 					func(cr *certificatesv1.CertificateSigningRequest) {
 						cr.CreationTimestamp = metav1.NewTime(fakeTimeObj2.Add(-2 * time.Minute))
 					},
 				),
-				testutil.SimpleIssuerFrom(issuer1),
+				testutil.SimpleClusterIssuerFrom(clusterIssuer1),
 			},
 			// instead of returning an error, we trigger a new reconciliation by setting requeue=true
 			validateError: errormatch.NoError(),
@@ -371,10 +371,10 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 						cr.CreationTimestamp = fakeTimeObj2
 					},
 					func(cr *certificatesv1.CertificateSigningRequest) {
-						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s", clusterIssuer1.GetIssuerTypeIdentifier(), clusterIssuer1.Name)
 					},
 				),
-				testutil.SimpleIssuerFrom(issuer1),
+				testutil.SimpleClusterIssuerFrom(clusterIssuer1),
 			},
 			// no error should be returned because the reconciliation should be triggered
 			// when the custom condition is added
@@ -418,7 +418,7 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 						cr.CreationTimestamp = fakeTimeObj2
 					},
 					func(cr *certificatesv1.CertificateSigningRequest) {
-						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s", clusterIssuer1.GetIssuerTypeIdentifier(), clusterIssuer1.Name)
 					},
 					cmgen.SetCertificateSigningRequestStatusCondition(certificatesv1.CertificateSigningRequestCondition{
 						Type:               "[condition type]",
@@ -429,7 +429,7 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 						LastUpdateTime:     fakeTimeObj2,
 					}),
 				),
-				testutil.SimpleIssuerFrom(issuer1),
+				testutil.SimpleClusterIssuerFrom(clusterIssuer1),
 			},
 			// instead of returning an error, we trigger a new reconciliation by setting requeue=true
 			validateError: errormatch.NoError(),
@@ -472,13 +472,13 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 			objects: []client.Object{
 				cmgen.CertificateSigningRequestFrom(cr1,
 					func(cr *certificatesv1.CertificateSigningRequest) {
-						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s", clusterIssuer1.GetIssuerTypeIdentifier(), clusterIssuer1.Name)
 					},
 					func(cr *certificatesv1.CertificateSigningRequest) {
 						cr.CreationTimestamp = metav1.NewTime(fakeTimeObj2.Add(-2 * time.Minute))
 					},
 				),
-				testutil.SimpleIssuerFrom(issuer1),
+				testutil.SimpleClusterIssuerFrom(clusterIssuer1),
 			},
 			// no error should be returned because the reconciliation should be triggered when the
 			// custom condition is added
@@ -527,7 +527,7 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 			objects: []client.Object{
 				cmgen.CertificateSigningRequestFrom(cr1,
 					func(cr *certificatesv1.CertificateSigningRequest) {
-						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s", clusterIssuer1.GetIssuerTypeIdentifier(), clusterIssuer1.Name)
 					},
 					func(cr *certificatesv1.CertificateSigningRequest) {
 						cr.CreationTimestamp = metav1.NewTime(fakeTimeObj2.Add(-2 * time.Minute))
@@ -541,7 +541,7 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 						LastUpdateTime:     fakeTimeObj1,
 					}),
 				),
-				testutil.SimpleIssuerFrom(issuer1),
+				testutil.SimpleClusterIssuerFrom(clusterIssuer1),
 			},
 			// since we got into a permanent failure state, we should not return an error
 			validateError: errormatch.NoError(),
@@ -588,13 +588,13 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 			objects: []client.Object{
 				cmgen.CertificateSigningRequestFrom(cr1,
 					func(cr *certificatesv1.CertificateSigningRequest) {
-						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s", clusterIssuer1.GetIssuerTypeIdentifier(), clusterIssuer1.Name)
 					},
 					func(cr *certificatesv1.CertificateSigningRequest) {
 						cr.CreationTimestamp = metav1.NewTime(fakeTimeObj2.Add(-2 * time.Minute))
 					},
 				),
-				testutil.SimpleIssuerFrom(issuer1),
+				testutil.SimpleClusterIssuerFrom(clusterIssuer1),
 			},
 			// no error should be returned because the reconciliation should be triggered
 			// when the custom condition is added
@@ -634,10 +634,10 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 			objects: []client.Object{
 				cmgen.CertificateSigningRequestFrom(cr1,
 					func(cr *certificatesv1.CertificateSigningRequest) {
-						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s", clusterIssuer1.GetIssuerTypeIdentifier(), clusterIssuer1.Name)
 					},
 				),
-				testutil.SimpleIssuerFrom(issuer1),
+				testutil.SimpleClusterIssuerFrom(clusterIssuer1),
 			},
 			// no error should be returned because we are in a permanent failure state no further
 			// retries should be made
@@ -676,10 +676,10 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 			objects: []client.Object{
 				cmgen.CertificateSigningRequestFrom(cr1,
 					func(cr *certificatesv1.CertificateSigningRequest) {
-						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s", clusterIssuer1.GetIssuerTypeIdentifier(), clusterIssuer1.Name)
 					},
 				),
-				testutil.SimpleIssuerFrom(issuer1),
+				testutil.SimpleClusterIssuerFrom(clusterIssuer1),
 			},
 			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
 				Conditions: []certificatesv1.CertificateSigningRequestCondition{
@@ -708,13 +708,13 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 			objects: []client.Object{
 				cmgen.CertificateSigningRequestFrom(cr1,
 					func(cr *certificatesv1.CertificateSigningRequest) {
-						cr.Spec.SignerName = fmt.Sprintf("%s/%s.%s", issuer1.GetIssuerTypeIdentifier(), issuer1.Namespace, issuer1.Name)
+						cr.Spec.SignerName = fmt.Sprintf("%s/%s", clusterIssuer1.GetIssuerTypeIdentifier(), clusterIssuer1.Name)
 					},
 					func(cr *certificatesv1.CertificateSigningRequest) {
 						cr.CreationTimestamp = fakeTimeObj2
 					},
 				),
-				testutil.SimpleIssuerFrom(issuer1),
+				testutil.SimpleClusterIssuerFrom(clusterIssuer1),
 			},
 			// instead of returning an error, we trigger a new reconciliation by setting requeue=true
 			validateError: errormatch.NoError(),
@@ -738,13 +738,8 @@ func TestCertificateSigningRequestReconcilerReconcile(t *testing.T) {
 				}),
 				testutil.SimpleIssuerFrom(issuer1),
 			},
-			expectedStatusPatch: &certificatesv1.CertificateSigningRequestStatus{
-				Certificate: []byte("a-signed-certificate"),
-				Conditions:  nil,
-			},
-			expectedEvents: []string{
-				"Normal Issued Succeeded signing the CertificateRequest",
-			},
+			expectedStatusPatch: nil,
+			expectedEvents:      []string{},
 		},
 
 		{
@@ -884,8 +879,9 @@ func TestCertificateSigningRequestMatchIssuerType(t *testing.T) {
 			clusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleClusterIssuer{}},
 			csr:                createCsr("simpleissuers.issuer.cert-manager.io/namespace.name"),
 
-			expectedIssuerType: &api.SimpleIssuer{},
-			expectedIssuerName: types.NamespacedName{Name: "name", Namespace: "namespace"},
+			expectedIssuerType: nil,
+			expectedIssuerName: types.NamespacedName{},
+			expectedError:      errormatch.ErrorContains("invalid SignerName, \"simpleissuers.issuer.cert-manager.io\" is a namespaced issuer type, namespaced issuers are not supported for Kubernetes CSRs"),
 		},
 		{
 			name:               "match cluster issuer",
@@ -895,43 +891,6 @@ func TestCertificateSigningRequestMatchIssuerType(t *testing.T) {
 
 			expectedIssuerType: &api.SimpleClusterIssuer{},
 			expectedIssuerName: types.NamespacedName{Name: "name"},
-		},
-		{
-			name:               "issuer with dot in name",
-			issuerTypes:        []v1alpha1.Issuer{&api.SimpleIssuer{}},
-			clusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleClusterIssuer{}},
-			csr:                createCsr("simpleissuers.issuer.cert-manager.io/namespace.name.test"),
-
-			expectedIssuerType: &api.SimpleIssuer{},
-			expectedIssuerName: types.NamespacedName{Namespace: "namespace", Name: "name.test"},
-		},
-		{
-			name:               "issuer with empty namespace",
-			issuerTypes:        []v1alpha1.Issuer{&api.SimpleIssuer{}},
-			clusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleClusterIssuer{}},
-			csr:                createCsr("simpleissuers.issuer.cert-manager.io/.name.test"),
-
-			expectedIssuerType: &api.SimpleIssuer{},
-			expectedIssuerName: types.NamespacedName{Namespace: "", Name: "name.test"},
-		},
-		{
-			name:               "issuer without dot in ID",
-			issuerTypes:        []v1alpha1.Issuer{&api.SimpleIssuer{}},
-			clusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleClusterIssuer{}},
-			csr:                createCsr("simpleissuers.issuer.cert-manager.io/test"),
-
-			expectedIssuerType: nil,
-			expectedIssuerName: types.NamespacedName{},
-			expectedError:      errormatch.ErrorContains("invalid issuer identifier, should have format simpleissuers.issuer.cert-manager.io/<namespace>.<name>: \"simpleissuers.issuer.cert-manager.io/test\""),
-		},
-		{
-			name:               "issuer with empty name",
-			issuerTypes:        []v1alpha1.Issuer{&api.SimpleIssuer{}},
-			clusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleClusterIssuer{}},
-			csr:                createCsr("simpleissuers.issuer.cert-manager.io/namespace."),
-
-			expectedIssuerType: &api.SimpleIssuer{},
-			expectedIssuerName: types.NamespacedName{Namespace: "namespace", Name: ""},
 		},
 		{
 			name:               "cluster issuer with dot in name",

--- a/controllers/combined_controller.go
+++ b/controllers/combined_controller.go
@@ -99,5 +99,23 @@ func (r *CombinedController) SetupWithManager(ctx context.Context, mgr ctrl.Mana
 		return fmt.Errorf("CertificateRequestReconciler: %w", err)
 	}
 
+	if err = (&CertificateSigningRequestReconciler{
+		IssuerTypes:        r.IssuerTypes,
+		ClusterIssuerTypes: r.ClusterIssuerTypes,
+
+		FieldOwner:       r.FieldOwner,
+		MaxRetryDuration: r.MaxRetryDuration,
+		EventSource:      eventSource,
+
+		Client:        cl,
+		Sign:          r.Sign,
+		EventRecorder: r.EventRecorder,
+		Clock:         r.Clock,
+
+		PostSetupWithManager: r.PostSetupWithManager,
+	}).SetupWithManager(ctx, mgr); err != nil {
+		return fmt.Errorf("CertificateRequestReconciler: %w", err)
+	}
+
 	return nil
 }

--- a/controllers/combined_controller_integration_test.go
+++ b/controllers/combined_controller_integration_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1alpha1 "github.com/cert-manager/issuer-lib/api/v1alpha1"
 	"github.com/cert-manager/issuer-lib/conditions"
@@ -68,7 +67,7 @@ func TestCombinedControllerTemporaryFailedCertificateRequestRetrigger(t *testing
 				ClusterIssuerTypes: []v1alpha1.Issuer{&api.SimpleClusterIssuer{}},
 				FieldOwner:         fieldOwner,
 				MaxRetryDuration:   time.Minute,
-				Check: func(_ context.Context, _ client.Object) error {
+				Check: func(_ context.Context, _ v1alpha1.Issuer) error {
 					select {
 					case err := <-checkResult:
 						return err
@@ -76,7 +75,7 @@ func TestCombinedControllerTemporaryFailedCertificateRequestRetrigger(t *testing
 						return ctx.Err()
 					}
 				},
-				Sign: func(_ context.Context, _ *cmapi.CertificateRequest, _ client.Object) ([]byte, error) {
+				Sign: func(_ context.Context, _ signer.CertificateRequestObject, _ v1alpha1.Issuer) ([]byte, error) {
 					select {
 					case err := <-signResult:
 						return nil, err

--- a/controllers/issuer_controller_test.go
+++ b/controllers/issuer_controller_test.go
@@ -93,7 +93,7 @@ func TestSimpleIssuerReconcilerReconcile(t *testing.T) {
 	)
 
 	staticChecker := func(err error) signer.Check {
-		return func(_ context.Context, _ client.Object) error {
+		return func(_ context.Context, _ v1alpha1.Issuer) error {
 			return err
 		}
 	}

--- a/controllers/predicates.go
+++ b/controllers/predicates.go
@@ -29,7 +29,8 @@ import (
 	"github.com/cert-manager/issuer-lib/conditions"
 )
 
-// Predicate for CertificateRequest changes that should trigger the CertificateRequest reconciler
+// This predicate is used to indicate when a CertificateRequest event should
+// trigger a reconciliation of itself.
 //
 // In these cases we want to trigger:
 // - an annotation changed/ was added or removed
@@ -53,7 +54,7 @@ func (CertificateRequestPredicate) Update(e event.UpdateEvent) bool {
 	}
 
 	if len(oldCr.Status.Conditions) != len(newCr.Status.Conditions) {
-		// fast-fail in case we are certain a non-ready condition was added/ removed
+		// Fail fast in case we are certain a non-ready condition was added or removed.
 		return true
 	}
 
@@ -74,7 +75,8 @@ func (CertificateRequestPredicate) Update(e event.UpdateEvent) bool {
 	return !reflect.DeepEqual(e.ObjectNew.GetAnnotations(), e.ObjectOld.GetAnnotations())
 }
 
-// Predicate for CertificateSigningRequest changes that should trigger the CertificateSigningRequest reconciler
+// This predicate is used to indicate when a CertificateSigningRequest event should
+// trigger a reconciliation of itself.
 //
 // In these cases we want to trigger:
 // - an annotation changed/ was added or removed
@@ -98,7 +100,7 @@ func (CertificateSigningRequestPredicate) Update(e event.UpdateEvent) bool {
 	}
 
 	if len(oldCr.Status.Conditions) != len(newCr.Status.Conditions) {
-		// fast-fail in case we are certain a non-ready condition was added/ removed
+		// Fail fast in case we are certain a non-ready condition was added or removed.
 		return true
 	}
 
@@ -114,7 +116,7 @@ func (CertificateSigningRequestPredicate) Update(e event.UpdateEvent) bool {
 	return !reflect.DeepEqual(e.ObjectNew.GetAnnotations(), e.ObjectOld.GetAnnotations())
 }
 
-// Predicate for Issuer changes that should trigger the CertificateRequest reconciler
+// Predicate for Issuer events that should trigger the CertificateRequest reconciler
 //
 // In these cases we want to trigger:
 // - the Ready condition was added/ removed
@@ -157,7 +159,7 @@ func (LinkedIssuerPredicate) Update(e event.UpdateEvent) bool {
 	return readyNew.Status != readyOld.Status
 }
 
-// Predicate for Issuer changes that should trigger the Issuer reconciler
+// Predicate for Issuer events that should trigger the Issuer reconciler
 //
 // In these cases we want to trigger:
 // - an annotation changed/ was added or removed

--- a/controllers/signer/interface.go
+++ b/controllers/signer/interface.go
@@ -40,8 +40,8 @@ type Check func(ctx context.Context, issuerObject v1alpha1.Issuer) error
 // labels and annotations of the underlying resource or any other metadata
 // fields that might be useful to the signer. Also, the signer can use the
 // GetConditions method to retrieve the conditions of the underlying resource.
-// To update the conditions, the signer should return an appropriate error
-// from the Sign method.
+// To update the conditions, the special error "SetCertificateRequestConditionError"
+// can be returned from the Sign method.
 type CertificateRequestObject interface {
 	metav1.Object
 

--- a/controllers/signer/interface.go
+++ b/controllers/signer/interface.go
@@ -29,6 +29,18 @@ import (
 type Sign func(ctx context.Context, cr CertificateRequestObject, issuerObject v1alpha1.Issuer) ([]byte, error)
 type Check func(ctx context.Context, issuerObject v1alpha1.Issuer) error
 
+// CertificateRequestObject is an interface that represents either a
+// cert-manager CertificateRequest or a Kubernetes CertificateSigningRequest
+// resource. This interface hides the spec fields of the underlying resource
+// and exposes a Certificate template and the raw CSR bytes instead. This
+// allows the signer to be agnostic of the underlying resource type and also
+// agnostic of the way the spec fields should be interpreted, such as the
+// defaulting logic that is applied to it. It is still possible to access the
+// labels and annotations of the underlying resource or any other metadata
+// fields that might be useful to the signer. Also, the signer can use the
+// GetConditions method to retrieve the conditions of the underlying resource.
+// To update the conditions, the signer should return an appropriate error
+// from the Sign method.
 type CertificateRequestObject interface {
 	metav1.Object
 

--- a/controllers/signer/interface.go
+++ b/controllers/signer/interface.go
@@ -19,6 +19,7 @@ package signer
 import (
 	"context"
 	"crypto/x509"
+	"time"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,7 +45,7 @@ type Check func(ctx context.Context, issuerObject v1alpha1.Issuer) error
 type CertificateRequestObject interface {
 	metav1.Object
 
-	GetRequest() (template *x509.Certificate, csr []byte, err error)
+	GetRequest() (template *x509.Certificate, duration time.Duration, csr []byte, err error)
 
 	GetConditions() []cmapi.CertificateRequestCondition
 }

--- a/controllers/signer/interface.go
+++ b/controllers/signer/interface.go
@@ -18,10 +18,21 @@ package signer
 
 import (
 	"context"
+	"crypto/x509"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cert-manager/issuer-lib/api/v1alpha1"
 )
 
-type Sign func(ctx context.Context, cr *cmapi.CertificateRequest, issuerObject client.Object) ([]byte, error)
-type Check func(ctx context.Context, issuerObject client.Object) error
+type Sign func(ctx context.Context, cr CertificateRequestObject, issuerObject v1alpha1.Issuer) ([]byte, error)
+type Check func(ctx context.Context, issuerObject v1alpha1.Issuer) error
+
+type CertificateRequestObject interface {
+	metav1.Object
+
+	GetRequest() (template *x509.Certificate, csr []byte, err error)
+
+	GetConditions() []cmapi.CertificateRequestCondition
+}

--- a/controllers/signer/interface_implementations.go
+++ b/controllers/signer/interface_implementations.go
@@ -1,0 +1,67 @@
+package signer
+
+import (
+	"crypto/x509"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/pkg/util/pki"
+	certificatesv1 "k8s.io/api/certificates/v1"
+)
+
+type certificateRequestImpl struct {
+	*cmapi.CertificateRequest
+}
+
+var _ CertificateRequestObject = &certificateRequestImpl{}
+
+func CertificateRequestObjectFromCertificateRequest(cr *cmapi.CertificateRequest) CertificateRequestObject {
+	return &certificateRequestImpl{cr}
+}
+
+func (c *certificateRequestImpl) GetRequest() (*x509.Certificate, []byte, error) {
+	template, err := pki.GenerateTemplateFromCertificateRequest(c.CertificateRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return template, c.Spec.Request, nil
+}
+
+func (c *certificateRequestImpl) GetConditions() []cmapi.CertificateRequestCondition {
+	return c.Status.Conditions
+}
+
+type certificateSigningRequestImpl struct {
+	*certificatesv1.CertificateSigningRequest
+}
+
+var _ CertificateRequestObject = &certificateSigningRequestImpl{}
+
+func CertificateRequestObjectFromCertificateSigningRequest(csr *certificatesv1.CertificateSigningRequest) CertificateRequestObject {
+	return &certificateSigningRequestImpl{csr}
+}
+
+func (c *certificateSigningRequestImpl) GetRequest() (*x509.Certificate, []byte, error) {
+	template, err := pki.GenerateTemplateFromCertificateSigningRequest(c.CertificateSigningRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return template, c.Spec.Request, nil
+}
+
+func (c *certificateSigningRequestImpl) GetConditions() []cmapi.CertificateRequestCondition {
+	conditions := make([]cmapi.CertificateRequestCondition, 0, len(c.Status.Conditions))
+	for _, condition := range c.Status.Conditions {
+		lastTransition := condition.LastTransitionTime
+		conditions = append(conditions, cmapi.CertificateRequestCondition{
+			Type:               cmapi.CertificateRequestConditionType(condition.Type),
+			Status:             cmmeta.ConditionStatus(condition.Status),
+			LastTransitionTime: &lastTransition,
+			Reason:             condition.Reason,
+			Message:            condition.Message,
+		})
+	}
+	return conditions
+}

--- a/internal/ssaclient/certificatesigningrequest.go
+++ b/internal/ssaclient/certificatesigningrequest.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ssaclient
+
+import (
+	"encoding/json"
+
+	certificatesv1 "k8s.io/api/certificates/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type certificateSigningRequestStatusApplyConfiguration struct {
+	v1.TypeMetaApplyConfiguration    `json:",inline"`
+	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
+	Status                           *certificatesv1.CertificateSigningRequestStatus `json:"status,omitempty"`
+}
+
+func GenerateCertificateSigningRequestStatusPatch(
+	name string,
+	namespace string,
+	status *certificatesv1.CertificateSigningRequestStatus,
+) (certificatesv1.CertificateSigningRequest, client.Patch, error) {
+	// This object is used to deduce the name & namespace + unmarshall the return value in
+	cr := certificatesv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+
+	// This object is used to render the patch
+	b := &certificateSigningRequestStatusApplyConfiguration{
+		ObjectMetaApplyConfiguration: &v1.ObjectMetaApplyConfiguration{},
+	}
+	b.WithName(name)
+	b.WithNamespace(namespace)
+	b.WithKind("CertificateSigningRequest")
+	b.WithAPIVersion(certificatesv1.SchemeGroupVersion.Identifier())
+	b.Status = status
+
+	encodedPatch, err := json.Marshal(b)
+	if err != nil {
+		return cr, nil, err
+	}
+
+	return cr, applyPatch{encodedPatch}, nil
+}

--- a/internal/tests/testresource/kube.go
+++ b/internal/tests/testresource/kube.go
@@ -27,6 +27,7 @@ import (
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/stretchr/testify/require"
+	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -56,6 +57,7 @@ func KubeClients(tb testing.TB, ctx context.Context) *OwnedKubeClients {
 
 	scheme := runtime.NewScheme()
 	require.NoError(tb, corev1.AddToScheme(scheme))
+	require.NoError(tb, certificatesv1.AddToScheme(scheme))
 	require.NoError(tb, cmapi.AddToScheme(scheme))
 	require.NoError(tb, api.AddToScheme(scheme))
 

--- a/internal/testsetups/simple/api/simple_cluster_issuer_types.go
+++ b/internal/testsetups/simple/api/simple_cluster_issuer_types.go
@@ -46,6 +46,10 @@ func (vi *SimpleClusterIssuer) GetStatus() *v1alpha1.IssuerStatus {
 	return &vi.Status
 }
 
+func (vi *SimpleClusterIssuer) GetIssuerTypeIdentifier() string {
+	return "simpleclusterissuers.issuer.cert-manager.io"
+}
+
 var _ v1alpha1.Issuer = &SimpleClusterIssuer{}
 
 // +kubebuilder:object:root=true

--- a/internal/testsetups/simple/api/simple_issuer_types.go
+++ b/internal/testsetups/simple/api/simple_issuer_types.go
@@ -45,6 +45,10 @@ func (vi *SimpleIssuer) GetStatus() *v1alpha1.IssuerStatus {
 	return &vi.Status
 }
 
+func (vi *SimpleIssuer) GetIssuerTypeIdentifier() string {
+	return "simpleissuers.issuer.cert-manager.io"
+}
+
 var _ v1alpha1.Issuer = &SimpleIssuer{}
 
 // +kubebuilder:object:root=true

--- a/internal/testsetups/simple/controller/signer.go
+++ b/internal/testsetups/simple/controller/signer.go
@@ -24,24 +24,28 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"fmt"
 	"math/big"
 	"time"
 
-	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cert-manager/issuer-lib/api/v1alpha1"
 	"github.com/cert-manager/issuer-lib/controllers"
+	"github.com/cert-manager/issuer-lib/controllers/signer"
 	"github.com/cert-manager/issuer-lib/internal/testsetups/simple/api"
 )
 
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificaterequests,verbs=get;list;watch
-// +kubebuilder:rbac:groups=cert-manager.io,resources=certificaterequests/status,verbs=get;patch
+// +kubebuilder:rbac:groups=cert-manager.io,resources=certificaterequests/status,verbs=patch
+
+// +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests,verbs=get;list;watch
+// +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests/status,verbs=patch
+// +kubebuilder:rbac:groups=certificates.k8s.io,resources=signers,verbs=sign,resourceNames=simpleissuers.issuer.cert-manager.io/*;simpleclusterissuers.issuer.cert-manager.io/*
 
 // +kubebuilder:rbac:groups=testing.cert-manager.io,resources=simpleissuers;simpleclusterissuers,verbs=get;list;watch
-// +kubebuilder:rbac:groups=testing.cert-manager.io,resources=simpleissuers/status;simpleclusterissuers/status,verbs=get;patch
+// +kubebuilder:rbac:groups=testing.cert-manager.io,resources=simpleissuers/status;simpleclusterissuers/status,verbs=patch
+
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 type Signer struct{}
 
@@ -59,11 +63,11 @@ func (s Signer) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	}).SetupWithManager(ctx, mgr)
 }
 
-func (Signer) Check(ctx context.Context, issuerObject client.Object) error {
+func (Signer) Check(ctx context.Context, issuerObject v1alpha1.Issuer) error {
 	return nil
 }
 
-func (Signer) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerObject client.Object) ([]byte, error) {
+func (Signer) Sign(ctx context.Context, cr signer.CertificateRequestObject, issuerObject v1alpha1.Issuer) ([]byte, error) {
 	// generate random ca private key
 	caPrivateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 	if err != nil {
@@ -84,31 +88,13 @@ func (Signer) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerObje
 	}
 
 	// load client certificate request
-	pemBlock, _ := pem.Decode(cr.Spec.Request)
-	if pemBlock == nil {
-		return nil, fmt.Errorf("pem.Decode failed")
-	}
-	clientCSR, err := x509.ParseCertificateRequest(pemBlock.Bytes)
+	clientCRTTemplate, _, err := cr.GetRequest()
 	if err != nil {
 		return nil, err
 	}
-	if err = clientCSR.CheckSignature(); err != nil {
-		return nil, err
-	}
-
-	// create client certificate template
-	clientCRTTemplate := x509.Certificate{
-		SerialNumber: big.NewInt(2),
-		Issuer:       caCRT.Subject,
-		Subject:      clientCSR.Subject,
-		NotBefore:    time.Now(),
-		NotAfter:     time.Now().Add(24 * time.Hour),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-	}
 
 	// create client certificate from template and CA public key
-	clientCRTRaw, err := x509.CreateCertificate(rand.Reader, &clientCRTTemplate, caCRT, clientCSR.PublicKey, caPrivateKey)
+	clientCRTRaw, err := x509.CreateCertificate(rand.Reader, clientCRTTemplate, caCRT, clientCRTTemplate.PublicKey, caPrivateKey)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/testsetups/simple/controller/signer.go
+++ b/internal/testsetups/simple/controller/signer.go
@@ -88,7 +88,7 @@ func (Signer) Sign(ctx context.Context, cr signer.CertificateRequestObject, issu
 	}
 
 	// load client certificate request
-	clientCRTTemplate, _, err := cr.GetRequest()
+	clientCRTTemplate, _, _, err := cr.GetRequest()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/testsetups/simple/deploy/rbac/role.yaml
+++ b/internal/testsetups/simple/deploy/rbac/role.yaml
@@ -18,7 +18,36 @@ rules:
   resources:
   - certificaterequests/status
   verbs:
+  - patch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/status
+  verbs:
+  - patch
+- apiGroups:
+  - certificates.k8s.io
+  resourceNames:
+  - simpleclusterissuers.issuer.cert-manager.io/*
+  - simpleissuers.issuer.cert-manager.io/*
+  resources:
+  - signers
+  verbs:
+  - sign
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
   - patch
 - apiGroups:
   - testing.cert-manager.io
@@ -35,5 +64,4 @@ rules:
   - simpleclusterissuers/status
   - simpleissuers/status
   verbs:
-  - get
   - patch

--- a/internal/testsetups/simple/e2e/e2e_test.go
+++ b/internal/testsetups/simple/e2e/e2e_test.go
@@ -17,23 +17,33 @@ limitations under the License.
 package e2e_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"fmt"
+	mathrand "math/rand"
 	"testing"
+	"time"
 
 	cmutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	cmgen "github.com/cert-manager/cert-manager/test/unit/gen"
 	"github.com/stretchr/testify/require"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/cert-manager/issuer-lib/internal/tests/testcontext"
 	"github.com/cert-manager/issuer-lib/internal/tests/testresource"
 	"github.com/cert-manager/issuer-lib/internal/testsetups/simple/testutil"
 )
 
-func TestSimple(t *testing.T) {
+func TestSimpleCertificate(t *testing.T) {
 	ctx := testresource.EnsureTestDependencies(t, testcontext.ForTest(t), testresource.EndToEndTest)
 
 	kubeClients := testresource.KubeClients(t, ctx)
@@ -76,4 +86,83 @@ func TestSimple(t *testing.T) {
 		return nil
 	}, watch.Added, watch.Modified)
 	require.NoError(t, err)
+}
+
+func TestSimpleCertificateSigningRequest(t *testing.T) {
+	ctx := testresource.EnsureTestDependencies(t, testcontext.ForTest(t), testresource.EndToEndTest)
+
+	kubeClients := testresource.KubeClients(t, ctx)
+
+	namespace, cleanup := kubeClients.SetupNamespace(t, ctx)
+	defer cleanup()
+
+	issuer := testutil.SimpleIssuer("issuer-test",
+		testutil.SetSimpleIssuerNamespace(namespace),
+	)
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	require.NoError(t, err)
+
+	csrBlob, err := cmgen.CSRWithSigner(privateKey,
+		cmgen.SetCSRCommonName("test.com"),
+	)
+	require.NoError(t, err)
+
+	csr := cmgen.CertificateSigningRequest(
+		"test-csr-"+randStringRunes(20),
+		cmgen.SetCertificateSigningRequestDuration("1h"),
+		cmgen.SetCertificateSigningRequestRequest(csrBlob),
+		cmgen.SetCertificateSigningRequestUsages([]certificatesv1.KeyUsage{certificatesv1.UsageDigitalSignature}),
+		cmgen.SetCertificateSigningRequestSignerName(fmt.Sprintf("simpleissuers.issuer.cert-manager.io/%s.%s", issuer.Namespace, issuer.Name)),
+	)
+
+	err = kubeClients.Client.Create(ctx, issuer)
+	require.NoError(t, err)
+
+	complete := kubeClients.StartObjectWatch(t, ctx, csr)
+
+	err = kubeClients.Client.Create(ctx, csr)
+	require.NoError(t, err)
+
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := kubeClients.Client.Get(ctx, types.NamespacedName{Name: csr.Name}, csr); err != nil {
+			return err
+		}
+
+		nowTime := metav1.NewTime(time.Now())
+
+		csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+			Type:           certificatesv1.CertificateApproved,
+			Reason:         "test",
+			Message:        "test",
+			LastUpdateTime: nowTime,
+			Status:         corev1.ConditionTrue,
+		})
+
+		return kubeClients.Client.SubResource("approval").Update(ctx, csr)
+	})
+	require.NoError(t, err)
+
+	err = complete(func(obj runtime.Object) error {
+		csr := obj.(*certificatesv1.CertificateSigningRequest)
+
+		if len(csr.Status.Certificate) == 0 {
+			return fmt.Errorf("certificate is not set (yet): %v", csr.Status.Certificate)
+		}
+
+		return nil
+	}, watch.Added, watch.Modified)
+	require.NoError(t, err)
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+// RandStringRunes - generate random string using random int
+func randStringRunes(n int) string {
+	b := make([]rune, n)
+	l := len(letterRunes)
+	for i := range b {
+		b[i] = letterRunes[mathrand.Intn(l)]
+	}
+	return string(b)
 }


### PR DESCRIPTION
This PR adds support for singing Kubernetes CSRs using your cluster issuer(s).
This features is enabled for anyone using this library.
The new Issuer interface requires you to implement the `GetIssuerTypeIdentifier()` function. The value returned by this function is used to determine if a Kubernetes CSR should be signed by the issuer.
eg. GetIssuerTypeIdentifier() returns "simpleissuers.issuer.cert-manager.io" and the CSR's signerName value is "simpleissuers.issuer.cert-manager.io/issuer-name".

CSR support is crucial for supporting integrations with other Cloud Native application that do not want to rely on the cert-manager APIs for their certificate creation (eg. service-meshes)