### PR TITLE
Add Status.CA support

### DIFF
--- a/controllers/certificatesigningrequest_controller.go
+++ b/controllers/certificatesigningrequest_controller.go
@@ -255,7 +255,7 @@ func (r *CertificateSigningRequestReconciler) reconcileStatusPatch(
 		}
 	}
 
-	csrStatusPatch.Certificate = signedCertificate
+	csrStatusPatch.Certificate = signedCertificate.ChainPEM
 
 	logger.V(1).Info("Successfully finished the reconciliation.")
 	r.EventRecorder.Eventf(&csr, corev1.EventTypeNormal, "Issued", "Succeeded signing the CertificateRequest")

--- a/controllers/combined_controller.go
+++ b/controllers/combined_controller.go
@@ -51,6 +51,13 @@ type CombinedController struct {
 	// Clock is used to mock condition transition times in tests.
 	Clock clock.PassiveClock
 
+	// SetCAOnCertificateRequest is used to enable setting the CA status field on
+	// the CertificateRequest resource. This is disabled by default.
+	// Deprecated: this option is for backwards compatibility only. The use of
+	// ca.crt is discouraged. Instead, the CA certificate should be provided
+	// separately using a tool such as trust-manager.
+	SetCAOnCertificateRequest bool
+
 	PostSetupWithManager func(context.Context, schema.GroupVersionKind, ctrl.Manager, controller.Controller) error
 }
 
@@ -93,6 +100,8 @@ func (r *CombinedController) SetupWithManager(ctx context.Context, mgr ctrl.Mana
 		Sign:          r.Sign,
 		EventRecorder: r.EventRecorder,
 		Clock:         r.Clock,
+
+		SetCAOnCertificateRequest: r.SetCAOnCertificateRequest,
 
 		PostSetupWithManager: r.PostSetupWithManager,
 	}).SetupWithManager(ctx, mgr); err != nil {

--- a/controllers/combined_controller_integration_test.go
+++ b/controllers/combined_controller_integration_test.go
@@ -75,12 +75,12 @@ func TestCombinedControllerTemporaryFailedCertificateRequestRetrigger(t *testing
 						return ctx.Err()
 					}
 				},
-				Sign: func(_ context.Context, _ signer.CertificateRequestObject, _ v1alpha1.Issuer) ([]byte, error) {
+				Sign: func(_ context.Context, _ signer.CertificateRequestObject, _ v1alpha1.Issuer) (signer.PEMBundle, error) {
 					select {
 					case err := <-signResult:
-						return nil, err
+						return signer.PEMBundle{}, err
 					case <-ctx.Done():
-						return nil, ctx.Err()
+						return signer.PEMBundle{}, ctx.Err()
 					}
 				},
 				EventRecorder: record.NewFakeRecorder(100),

--- a/controllers/signer/interface.go
+++ b/controllers/signer/interface.go
@@ -22,12 +22,23 @@ import (
 	"time"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cert-manager/issuer-lib/api/v1alpha1"
 )
 
-type Sign func(ctx context.Context, cr CertificateRequestObject, issuerObject v1alpha1.Issuer) ([]byte, error)
+// PEMBundle includes the PEM encoded X.509 certificate chain and CA.
+// The first certificate in the ChainPEM chain is the leaf certificate, and the
+// last certificate in the chain is the highest level non-self-signed certificate.
+// The CAPEM certificate is our best guess at the CA that issued the leaf.
+// IMORTANT: the CAPEM certificate is only used when the SetCAOnCertificateRequest
+// option is enabled in the controller. This option is for backwards compatibility
+// only. The use of the CA field and the ca.crt field in the resulting Secret is
+// discouraged, instead the CA should be provisioned separately (e.g. using trust-manager).
+type PEMBundle pki.PEMBundle
+
+type Sign func(ctx context.Context, cr CertificateRequestObject, issuerObject v1alpha1.Issuer) (PEMBundle, error)
 type Check func(ctx context.Context, issuerObject v1alpha1.Issuer) error
 
 // CertificateRequestObject is an interface that represents either a

--- a/internal/testsetups/simple/controller/signer.go
+++ b/internal/testsetups/simple/controller/signer.go
@@ -67,11 +67,11 @@ func (Signer) Check(ctx context.Context, issuerObject v1alpha1.Issuer) error {
 	return nil
 }
 
-func (Signer) Sign(ctx context.Context, cr signer.CertificateRequestObject, issuerObject v1alpha1.Issuer) ([]byte, error) {
+func (Signer) Sign(ctx context.Context, cr signer.CertificateRequestObject, issuerObject v1alpha1.Issuer) (signer.PEMBundle, error) {
 	// generate random ca private key
 	caPrivateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 	if err != nil {
-		return nil, err
+		return signer.PEMBundle{}, err
 	}
 
 	caCRT := &x509.Certificate{
@@ -90,7 +90,7 @@ func (Signer) Sign(ctx context.Context, cr signer.CertificateRequestObject, issu
 	// load client certificate request
 	clientCRTTemplate, _, _, err := cr.GetRequest()
 	if err != nil {
-		return nil, err
+		return signer.PEMBundle{}, err
 	}
 
 	// create client certificate from template and CA public key
@@ -100,5 +100,7 @@ func (Signer) Sign(ctx context.Context, cr signer.CertificateRequestObject, issu
 	}
 
 	clientCrt := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientCRTRaw})
-	return clientCrt, nil
+	return signer.PEMBundle{
+		ChainPEM: clientCrt,
+	}, nil
 }


### PR DESCRIPTION
Adds the option to set the CA status field on a CertificateRequest resource (for backwards compatibility).

⚠️ This PR changes the Sign signature and is a breaking change! You will have to change your sign function to work with the new signature.

HINT: you can use cert-manager's `pki.ParseSingleCertificateChainPEM(certPem)` to obtain a `signer.PEMBundle`