### PR TITLE
Add functions to ignore certain issuers and/or CertificateRequests, Kubernetes CSRs

### DIFF
--- a/controllers/certificaterequest_controller.go
+++ b/controllers/certificaterequest_controller.go
@@ -163,7 +163,7 @@ func (r *CertificateRequestReconciler) reconcileStatusPatch(
 	}
 
 	if r.IgnoreCertificateRequest != nil {
-		ignore, err := r.IgnoreCertificateRequest(ctx, signer.CertificateRequestObjectFromCertificateRequest(&cr))
+		ignore, err := r.IgnoreCertificateRequest(ctx, signer.CertificateRequestObjectFromCertificateRequest(&cr), issuerGvk, issuerName)
 		if err != nil {
 			return result, nil, fmt.Errorf("failed to check if CertificateRequest should be ignored: %v", err) // retry
 		}

--- a/controllers/certificatesigningrequest_controller.go
+++ b/controllers/certificatesigningrequest_controller.go
@@ -64,6 +64,9 @@ type CertificateSigningRequestReconciler struct {
 	client.Client
 	// Sign connects to a CA and returns a signed certificate for the supplied CertificateRequest.
 	signer.Sign
+	// IgnoreCertificateRequest is an optional function that can prevent the CertificateRequest
+	// and Kubernetes CSR controllers from reconciling a CertificateRequest resource.
+	signer.IgnoreCertificateRequest
 
 	// EventRecorder is used for creating Kubernetes events on resources.
 	EventRecorder record.EventRecorder
@@ -148,6 +151,17 @@ func (r *CertificateSigningRequestReconciler) reconcileStatusPatch(
 	if util.CertificateSigningRequestIsDenied(&csr) {
 		logger.V(1).Info("CertificateSigningRequest is Denied. Ignoring.")
 		return result, nil, nil // done
+	}
+
+	if r.IgnoreCertificateRequest != nil {
+		ignore, err := r.IgnoreCertificateRequest(ctx, signer.CertificateRequestObjectFromCertificateSigningRequest(&csr))
+		if err != nil {
+			return result, nil, fmt.Errorf("failed to check if CertificateSigningRequest should be ignored: %v", err) // retry
+		}
+		if ignore {
+			logger.V(1).Info("Ignoring CertificateSigningRequest")
+			return result, nil, nil // done
+		}
 	}
 
 	// We now have a CertificateSigningRequestStatus that belongs to us so we are responsible

--- a/controllers/certificatesigningrequest_controller.go
+++ b/controllers/certificatesigningrequest_controller.go
@@ -154,7 +154,7 @@ func (r *CertificateSigningRequestReconciler) reconcileStatusPatch(
 	}
 
 	if r.IgnoreCertificateRequest != nil {
-		ignore, err := r.IgnoreCertificateRequest(ctx, signer.CertificateRequestObjectFromCertificateSigningRequest(&csr))
+		ignore, err := r.IgnoreCertificateRequest(ctx, signer.CertificateRequestObjectFromCertificateSigningRequest(&csr), issuerGvk, issuerName)
 		if err != nil {
 			return result, nil, fmt.Errorf("failed to check if CertificateSigningRequest should be ignored: %v", err) // retry
 		}

--- a/controllers/combined_controller.go
+++ b/controllers/combined_controller.go
@@ -45,6 +45,13 @@ type CombinedController struct {
 	// Sign connects to a CA and returns a signed certificate for the supplied CertificateRequest.
 	signer.Sign
 
+	// IgnoreCertificateRequest is an optional function that can prevent the CertificateRequest
+	// and Kubernetes CSR controllers from reconciling a CertificateRequest resource.
+	signer.IgnoreCertificateRequest
+	// IgnoreIssuer is an optional function that can prevent the issuer controllers from
+	// reconciling an issuer resource.
+	signer.IgnoreIssuer
+
 	// EventRecorder is used for creating Kubernetes events on resources.
 	EventRecorder record.EventRecorder
 
@@ -72,6 +79,7 @@ func (r *CombinedController) SetupWithManager(ctx context.Context, mgr ctrl.Mana
 
 			Client:        cl,
 			Check:         r.Check,
+			IgnoreIssuer:  r.IgnoreIssuer,
 			EventRecorder: r.EventRecorder,
 			Clock:         r.Clock,
 
@@ -89,10 +97,11 @@ func (r *CombinedController) SetupWithManager(ctx context.Context, mgr ctrl.Mana
 		MaxRetryDuration: r.MaxRetryDuration,
 		EventSource:      eventSource,
 
-		Client:        cl,
-		Sign:          r.Sign,
-		EventRecorder: r.EventRecorder,
-		Clock:         r.Clock,
+		Client:                   cl,
+		Sign:                     r.Sign,
+		IgnoreCertificateRequest: r.IgnoreCertificateRequest,
+		EventRecorder:            r.EventRecorder,
+		Clock:                    r.Clock,
 
 		PostSetupWithManager: r.PostSetupWithManager,
 	}).SetupWithManager(ctx, mgr); err != nil {
@@ -107,10 +116,11 @@ func (r *CombinedController) SetupWithManager(ctx context.Context, mgr ctrl.Mana
 		MaxRetryDuration: r.MaxRetryDuration,
 		EventSource:      eventSource,
 
-		Client:        cl,
-		Sign:          r.Sign,
-		EventRecorder: r.EventRecorder,
-		Clock:         r.Clock,
+		Client:                   cl,
+		Sign:                     r.Sign,
+		IgnoreCertificateRequest: r.IgnoreCertificateRequest,
+		EventRecorder:            r.EventRecorder,
+		Clock:                    r.Clock,
 
 		PostSetupWithManager: r.PostSetupWithManager,
 	}).SetupWithManager(ctx, mgr); err != nil {

--- a/controllers/signer/interface.go
+++ b/controllers/signer/interface.go
@@ -23,6 +23,8 @@ import (
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/cert-manager/issuer-lib/api/v1alpha1"
 )
@@ -50,12 +52,20 @@ type CertificateRequestObject interface {
 	GetConditions() []cmapi.CertificateRequestCondition
 }
 
-// IgnoreCertificateRequest is an optional function that can prevent the CertificateRequest
-// and Kubernetes CSR controllers from reconciling a CertificateRequest resource. By default,
-// the controllers will reconcile all CertificateRequest resources that match the issuerRef type.
-type IgnoreCertificateRequest func(ctx context.Context, cr CertificateRequestObject) (bool, error)
-
 // IgnoreIssuer is an optional function that can prevent the issuer controllers from
 // reconciling an issuer resource. By default, the controllers will reconcile all
 // issuer resources that match the owned types.
-type IgnoreIssuer func(ctx context.Context, issuerObject v1alpha1.Issuer) (bool, error)
+type IgnoreIssuer func(
+	ctx context.Context,
+	issuerObject v1alpha1.Issuer,
+) (bool, error)
+
+// IgnoreCertificateRequest is an optional function that can prevent the CertificateRequest
+// and Kubernetes CSR controllers from reconciling a CertificateRequest resource. By default,
+// the controllers will reconcile all CertificateRequest resources that match the issuerRef type.
+type IgnoreCertificateRequest func(
+	ctx context.Context,
+	cr CertificateRequestObject,
+	issuerGvk schema.GroupVersionKind,
+	issuerName types.NamespacedName,
+) (bool, error)

--- a/controllers/signer/interface.go
+++ b/controllers/signer/interface.go
@@ -49,3 +49,13 @@ type CertificateRequestObject interface {
 
 	GetConditions() []cmapi.CertificateRequestCondition
 }
+
+// IgnoreCertificateRequest is an optional function that can prevent the CertificateRequest
+// and Kubernetes CSR controllers from reconciling a CertificateRequest resource. By default,
+// the controllers will reconcile all CertificateRequest resources that match the issuerRef type.
+type IgnoreCertificateRequest func(ctx context.Context, cr CertificateRequestObject) (bool, error)
+
+// IgnoreIssuer is an optional function that can prevent the issuer controllers from
+// reconciling an issuer resource. By default, the controllers will reconcile all
+// issuer resources that match the owned types.
+type IgnoreIssuer func(ctx context.Context, issuerObject v1alpha1.Issuer) (bool, error)

--- a/controllers/signer/interface.go
+++ b/controllers/signer/interface.go
@@ -55,6 +55,9 @@ type CertificateRequestObject interface {
 // IgnoreIssuer is an optional function that can prevent the issuer controllers from
 // reconciling an issuer resource. By default, the controllers will reconcile all
 // issuer resources that match the owned types.
+// This function will be called by the issuer reconcile loops for each type that matches
+// the owned types. If the function returns true, the controller will not reconcile the
+// issuer resource.
 type IgnoreIssuer func(
 	ctx context.Context,
 	issuerObject v1alpha1.Issuer,
@@ -63,6 +66,9 @@ type IgnoreIssuer func(
 // IgnoreCertificateRequest is an optional function that can prevent the CertificateRequest
 // and Kubernetes CSR controllers from reconciling a CertificateRequest resource. By default,
 // the controllers will reconcile all CertificateRequest resources that match the issuerRef type.
+// This function will be called by the CertificateRequest reconcile loop and the Kubernetes CSR
+// reconcile loop for each type that matches the issuerRef type. If the function returns true,
+// the controller will not reconcile the CertificateRequest resource.
 type IgnoreCertificateRequest func(
 	ctx context.Context,
 	cr CertificateRequestObject,


### PR DESCRIPTION
This new options allows implementers to ignore certain issuers (eg. only reconcile all issuers that live in a specific namespace or only reconcile issuers that have a name starting with a certain prefix).
Also, we can ignore the certificate requests that refer to these issuers.

This is useful when you are partitioning issuers (eg. one instance reconciles all issuers with a certain name prefix, while another issuer instance reconciles the other issuers).