### PR TITLE
Also reconcile when the linked issuer receives an update

### DIFF
--- a/controllers/predicates.go
+++ b/controllers/predicates.go
@@ -121,6 +121,7 @@ func (CertificateSigningRequestPredicate) Update(e event.UpdateEvent) bool {
 // In these cases we want to trigger:
 // - the Ready condition was added/ removed
 // - the Ready condition's Status property changed
+// - the Ready condition's observed generation changed
 type LinkedIssuerPredicate struct {
 	predicate.Funcs
 }
@@ -156,7 +157,7 @@ func (LinkedIssuerPredicate) Update(e event.UpdateEvent) bool {
 		return readyOld != nil || readyNew != nil
 	}
 
-	return readyNew.Status != readyOld.Status
+	return readyNew.Status != readyOld.Status || readyNew.ObservedGeneration != readyOld.ObservedGeneration
 }
 
 // Predicate for Issuer events that should trigger the Issuer reconciler

--- a/controllers/predicates_test.go
+++ b/controllers/predicates_test.go
@@ -507,6 +507,31 @@ func TestLinkedIssuerPredicate(t *testing.T) {
 			},
 		},
 		{
+			name:            "ready-condition-identical-new-observed-generation",
+			shouldReconcile: true,
+			event: event.UpdateEvent{
+				ObjectOld: testutil.SimpleIssuerFrom(issuer1,
+					testutil.SetSimpleIssuerStatusCondition(
+						fakeClock,
+						cmapi.IssuerConditionReady,
+						cmmeta.ConditionFalse,
+						"reason1",
+						"message1",
+					),
+				),
+				ObjectNew: testutil.SimpleIssuerFrom(issuer1,
+					testutil.SetSimpleIssuerGeneration(2),
+					testutil.SetSimpleIssuerStatusCondition(
+						fakeClock,
+						cmapi.IssuerConditionReady,
+						cmmeta.ConditionFalse,
+						"reason2",
+						"message2",
+					),
+				),
+			},
+		},
+		{
 			name:            "ready-condition-changed",
 			shouldReconcile: true,
 			event: event.UpdateEvent{


### PR DESCRIPTION
The predicates prevent us from reconciling on each update. However, we were missing a situation in which we should reconcile:
1. an issuer is a Ready state; but the CertificateRequest is failing because of a mismatch in eg. policy
2. we update the issuer so the policy allows the CertificateRequest to not fail

Currently, we won't auto re-reconcile the CertificateRequest when the issuer changes if the issuer Ready condition's Status does not change.