### PR TITLE
Unify the CertificateRequest + CertificateSigningRequest controllers

### DIFF
--- a/controllers/certificaterequest_controller.go
+++ b/controllers/certificaterequest_controller.go
@@ -18,60 +18,20 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"time"
 
-	cmutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/clock"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1alpha1 "github.com/cert-manager/issuer-lib/api/v1alpha1"
-	"github.com/cert-manager/issuer-lib/conditions"
-	"github.com/cert-manager/issuer-lib/controllers/signer"
-	"github.com/cert-manager/issuer-lib/internal/kubeutil"
-	"github.com/cert-manager/issuer-lib/internal/ssaclient"
 )
 
 // CertificateRequestReconciler reconciles a CertificateRequest object
 type CertificateRequestReconciler struct {
-	IssuerTypes        []v1alpha1.Issuer
-	ClusterIssuerTypes []v1alpha1.Issuer
-
-	FieldOwner       string
-	MaxRetryDuration time.Duration
-	EventSource      kubeutil.EventSource
-
-	// Client is a controller-runtime client used to get and set K8S API resources
-	client.Client
-	// Sign connects to a CA and returns a signed certificate for the supplied CertificateRequest.
-	signer.Sign
-	// IgnoreCertificateRequest is an optional function that can prevent the CertificateRequest
-	// and Kubernetes CSR controllers from reconciling a CertificateRequest resource.
-	signer.IgnoreCertificateRequest
-
-	// EventRecorder is used for creating Kubernetes events on resources.
-	EventRecorder record.EventRecorder
-
-	// Clock is used to mock condition transition times in tests.
-	Clock clock.PassiveClock
+	RequestController
 
 	// SetCAOnCertificateRequest is used to enable setting the CA status field on
 	// the CertificateRequest resource. This is disabled by default.
@@ -79,335 +39,18 @@ type CertificateRequestReconciler struct {
 	// ca.crt is discouraged. Instead, the CA certificate should be provided
 	// separately using a tool such as trust-manager.
 	SetCAOnCertificateRequest bool
-
-	PostSetupWithManager func(context.Context, schema.GroupVersionKind, ctrl.Manager, controller.Controller) error
 }
 
-func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx).WithName("Reconcile")
+func (r *CertificateRequestReconciler) matchIssuerType(requestObject client.Object) (v1alpha1.Issuer, types.NamespacedName, error) {
+	cr := requestObject.(*cmapi.CertificateRequest)
 
-	logger.V(2).Info("Starting reconcile loop", "name", req.Name, "namespace", req.Namespace)
-
-	// The error returned by `reconcileStatusPatch` is meant for controller-runtime,
-	// not for us. That's why we aren't checking `reconcileError != nil` .
-	result, crStatusPatch, reconcileError := r.reconcileStatusPatch(logger, ctx, req)
-
-	logger.V(2).Info("Got StatusPatch result", "result", result, "patch", crStatusPatch, "error", reconcileError)
-
-	if crStatusPatch != nil {
-		cr, patch, err := ssaclient.GenerateCertificateRequestStatusPatch(req.Name, req.Namespace, crStatusPatch)
-		if err != nil {
-			return ctrl.Result{}, utilerrors.NewAggregate([]error{err, reconcileError})
-		}
-
-		if err := r.Client.Status().Patch(ctx, &cr, patch, &client.SubResourcePatchOptions{
-			PatchOptions: client.PatchOptions{
-				FieldManager: r.FieldOwner,
-				Force:        ptr.To(true),
-			},
-		}); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return ctrl.Result{}, utilerrors.NewAggregate([]error{err, reconcileError}) // requeue with backoff
-			}
-
-			logger.V(1).Info("Not found. Ignoring.")
-		}
-	}
-
-	return result, reconcileError
-}
-
-// reconcileStatusPatch is responsible for reconciling the cert-manager
-// CertificateRequest resource. It will return the result and reconcileError
-// to be returned by the Reconcile function. It also returns a statusPatch that
-// the Reconcile function will apply to the request resource's status. This function
-// is split out from the Reconcile function to allow for easier testing.
-//
-// The error returned by `reconcileStatusPatch` is meant for controller-runtime,
-// not for the caller. The caller must not check the error (i.e., they must not
-// do `if err != nil...`).
-func (r *CertificateRequestReconciler) reconcileStatusPatch(
-	logger logr.Logger,
-	ctx context.Context,
-	req ctrl.Request,
-) (result ctrl.Result, crStatusPatch *cmapi.CertificateRequestStatus, returnedError error) {
-	var cr cmapi.CertificateRequest
-	if err := r.Client.Get(ctx, req.NamespacedName, &cr); err != nil && apierrors.IsNotFound(err) {
-		logger.V(1).Info("Not found. Ignoring.")
-		return result, nil, nil // done
-	} else if err != nil {
-		return result, nil, fmt.Errorf("unexpected get error: %v", err) // retry
-	}
-
-	// Ignore CertificateRequest if it has not yet been assigned an approval
-	// status condition by an approval controller.
-	if !cmutil.CertificateRequestIsApproved(&cr) && !cmutil.CertificateRequestIsDenied(&cr) {
-		logger.V(1).Info("CertificateRequest has not been approved or denied. Ignoring.")
-		return result, nil, nil // done
-	}
-
-	// Select first matching issuer type and construct an issuerObject and issuerName
-	issuerObject, issuerName, err := r.matchIssuerType(&cr)
-	// Ignore CertificateRequest if issuerRef doesn't match one of our issuer Types
-	if err != nil {
-		logger.V(1).Info("Foreign issuer. Ignoring.", "error", err)
-		return result, nil, nil // done
-	}
-	issuerGvk := issuerObject.GetObjectKind().GroupVersionKind()
-
-	// Ignore CertificateRequest if it is already Ready
-	if cmutil.CertificateRequestHasCondition(&cr, cmapi.CertificateRequestCondition{
-		Type:   cmapi.CertificateRequestConditionReady,
-		Status: cmmeta.ConditionTrue,
-	}) {
-		logger.V(1).Info("CertificateRequest is Ready. Ignoring.")
-		return result, nil, nil // done
-	}
-
-	// Ignore CertificateRequest if it is already Failed
-	if cmutil.CertificateRequestHasCondition(&cr, cmapi.CertificateRequestCondition{
-		Type:   cmapi.CertificateRequestConditionReady,
-		Status: cmmeta.ConditionFalse,
-		Reason: cmapi.CertificateRequestReasonFailed,
-	}) {
-		logger.V(1).Info("CertificateRequest is Failed. Ignoring.")
-		return result, nil, nil // done
-	}
-
-	// Ignore CertificateRequest if it is already Denied
-	if cmutil.CertificateRequestHasCondition(&cr, cmapi.CertificateRequestCondition{
-		Type:   cmapi.CertificateRequestConditionReady,
-		Status: cmmeta.ConditionFalse,
-		Reason: cmapi.CertificateRequestReasonDenied,
-	}) {
-		logger.V(1).Info("CertificateRequest already has a Ready condition with Denied Reason. Ignoring.")
-		return result, nil, nil // done
-	}
-
-	if r.IgnoreCertificateRequest != nil {
-		ignore, err := r.IgnoreCertificateRequest(ctx, signer.CertificateRequestObjectFromCertificateRequest(&cr), issuerGvk, issuerName)
-		if err != nil {
-			return result, nil, fmt.Errorf("failed to check if CertificateRequest should be ignored: %v", err) // retry
-		}
-		if ignore {
-			logger.V(1).Info("Ignoring CertificateRequest")
-			return result, nil, nil // done
-		}
-	}
-
-	// We now have a CertificateRequest that belongs to us so we are responsible
-	// for updating its Status.
-	crStatusPatch = &cmapi.CertificateRequestStatus{}
-
-	// Add a Ready condition if one does not already exist. Set initial Status
-	// to Unknown.
-	if ready := cmutil.GetCertificateRequestCondition(&cr, cmapi.CertificateRequestConditionReady); ready == nil {
-		logger.V(1).Info("Initializing Ready condition")
-		conditions.SetCertificateRequestStatusCondition(
-			r.Clock,
-			cr.Status.Conditions,
-			&crStatusPatch.Conditions,
-			cmapi.CertificateRequestConditionReady,
-			cmmeta.ConditionUnknown,
-			v1alpha1.CertificateRequestConditionReasonInitializing,
-			fmt.Sprintf("%s has started reconciling this CertificateRequest", r.FieldOwner),
-		)
-		// To continue reconciling this CertificateRequest, we must re-run the reconcile loop
-		// after adding the Unknown Ready condition. This update will trigger a
-		// new reconcile loop, so we don't need to requeue here.
-		return result, crStatusPatch, nil // apply patch, done
-	}
-
-	if cmutil.CertificateRequestIsDenied(&cr) {
-		logger.V(1).Info("CertificateRequest has been denied. Marking as failed.")
-		_, failedAt := conditions.SetCertificateRequestStatusCondition(
-			r.Clock,
-			cr.Status.Conditions,
-			&crStatusPatch.Conditions,
-			cmapi.CertificateRequestConditionReady,
-			cmmeta.ConditionFalse,
-			cmapi.CertificateRequestReasonDenied,
-			"Detected that the CertificateRequest is denied, so it will never be Ready.",
-		)
-		crStatusPatch.FailureTime = failedAt.DeepCopy()
-		r.EventRecorder.Eventf(&cr, corev1.EventTypeWarning, "PermanentError", "Detected that the CertificateRequest is denied, so it will never be Ready.")
-		return result, crStatusPatch, nil // done, apply patch
-	}
-
-	if err := r.Client.Get(ctx, issuerName, issuerObject); err != nil && apierrors.IsNotFound(err) {
-		logger.V(1).Info("Issuer not found. Waiting for it to be created")
-		conditions.SetCertificateRequestStatusCondition(
-			r.Clock,
-			cr.Status.Conditions,
-			&crStatusPatch.Conditions,
-			cmapi.CertificateRequestConditionReady,
-			cmmeta.ConditionFalse,
-			cmapi.CertificateRequestReasonPending,
-			fmt.Sprintf("%s. Waiting for it to be created.", err),
-		)
-		r.EventRecorder.Eventf(&cr, corev1.EventTypeNormal, "WaitingForIssuerExist", fmt.Sprintf("%s. Waiting for it to be created.", err))
-		return result, crStatusPatch, nil // done, apply patch
-	} else if err != nil {
-		r.EventRecorder.Eventf(&cr, corev1.EventTypeWarning, "UnexpectedError", "Got an unexpected error while processing the CR")
-		return result, nil, fmt.Errorf("unexpected get error: %v", err) // retry
-	}
-
-	readyCondition := conditions.GetIssuerStatusCondition(
-		issuerObject.GetStatus().Conditions,
-		cmapi.IssuerConditionReady,
-	)
-	if (readyCondition == nil) ||
-		(readyCondition.Status != cmmeta.ConditionTrue) ||
-		(readyCondition.ObservedGeneration < issuerObject.GetGeneration()) {
-
-		message := ""
-		if readyCondition == nil {
-			message = "Waiting for issuer to become ready. Current issuer ready condition: <none>."
-		} else if readyCondition.Status != cmmeta.ConditionTrue {
-			message = fmt.Sprintf("Waiting for issuer to become ready. Current issuer ready condition is \"%s\": %s.", readyCondition.Reason, readyCondition.Message)
-		} else {
-			message = "Waiting for issuer to become ready. Current issuer ready condition is outdated."
-		}
-
-		logger.V(1).Info("Issuer is not Ready yet. Waiting for it to become ready.", "issuer ready condition", readyCondition)
-		conditions.SetCertificateRequestStatusCondition(
-			r.Clock,
-			cr.Status.Conditions,
-			&crStatusPatch.Conditions,
-			cmapi.CertificateRequestConditionReady,
-			cmmeta.ConditionFalse,
-			cmapi.CertificateRequestReasonPending,
-			message,
-		)
-		r.EventRecorder.Eventf(&cr, corev1.EventTypeNormal, "WaitingForIssuerReady", message)
-		return result, crStatusPatch, nil // done, apply patch
-	}
-
-	signedCertificate, err := r.Sign(log.IntoContext(ctx, logger), signer.CertificateRequestObjectFromCertificateRequest(&cr), issuerObject)
-	if err != nil {
-		// An error in the issuer part of the operator should trigger a reconcile
-		// of the issuer's state.
-		if issuerError := new(signer.IssuerError); errors.As(err, issuerError) {
-			if reportError := r.EventSource.ReportError(
-				issuerGvk, client.ObjectKeyFromObject(issuerObject),
-				issuerError.Err,
-			); reportError != nil {
-				err = utilerrors.NewAggregate([]error{err, reportError})
-			}
-
-			logger.V(1).Error(err, "Temporary CertificateRequest error.")
-			conditions.SetCertificateRequestStatusCondition(
-				r.Clock,
-				cr.Status.Conditions,
-				&crStatusPatch.Conditions,
-				cmapi.CertificateRequestConditionReady,
-				cmmeta.ConditionFalse,
-				cmapi.CertificateRequestReasonPending,
-				"Waiting for issuer to become ready. Current issuer ready condition is outdated.",
-			)
-			r.EventRecorder.Eventf(&cr, corev1.EventTypeWarning, "WaitingForIssuerReady", "Waiting for issuer to become ready. Current issuer ready condition is outdated.")
-			return result, crStatusPatch, reconcile.TerminalError(err) // done, apply patch
-		}
-
-		didCustomConditionTransition := false
-
-		if targetCustom := new(signer.SetCertificateRequestConditionError); errors.As(err, targetCustom) {
-			logger.V(1).Info("Set CertificateRequestCondition error. Setting condition.", "error", err)
-			conditions.SetCertificateRequestStatusCondition(
-				r.Clock,
-				cr.Status.Conditions,
-				&crStatusPatch.Conditions,
-				targetCustom.ConditionType,
-				targetCustom.Status,
-				targetCustom.Reason,
-				targetCustom.Error(),
-			)
-
-			// check if the custom condition transitioned
-			currentCustom := cmutil.GetCertificateRequestCondition(&cr, targetCustom.ConditionType)
-			didCustomConditionTransition = currentCustom == nil || currentCustom.Status != targetCustom.Status
-		}
-
-		// Check if we have still time to requeue & retry
-		isPendingError := errors.As(err, &signer.PendingError{})
-		isPermanentError := errors.As(err, &signer.PermanentError{})
-		pastMaxRetryDuration := r.Clock.Now().After(cr.CreationTimestamp.Add(r.MaxRetryDuration))
-		if !isPendingError && (isPermanentError || pastMaxRetryDuration) {
-			// fail permanently
-			logger.V(1).Error(err, "Permanent CertificateRequest error. Marking as failed.")
-			_, failedAt := conditions.SetCertificateRequestStatusCondition(
-				r.Clock,
-				cr.Status.Conditions,
-				&crStatusPatch.Conditions,
-				cmapi.CertificateRequestConditionReady,
-				cmmeta.ConditionFalse,
-				cmapi.CertificateRequestReasonFailed,
-				fmt.Sprintf("Failed permanently to sign CertificateRequest: %s", err),
-			)
-			crStatusPatch.FailureTime = failedAt.DeepCopy()
-			r.EventRecorder.Eventf(&cr, corev1.EventTypeWarning, "PermanentError", "Failed permanently to sign CertificateRequest: %s", err)
-			return result, crStatusPatch, reconcile.TerminalError(err) // done, apply patch
-		} else {
-			// retry
-			logger.V(1).Error(err, "Retryable CertificateRequest error.")
-			conditions.SetCertificateRequestStatusCondition(
-				r.Clock,
-				cr.Status.Conditions,
-				&crStatusPatch.Conditions,
-				cmapi.CertificateRequestConditionReady,
-				cmmeta.ConditionFalse,
-				cmapi.CertificateRequestReasonPending,
-				fmt.Sprintf("Failed to sign CertificateRequest, will retry: %s", err),
-			)
-
-			r.EventRecorder.Eventf(&cr, corev1.EventTypeWarning, "RetryableError", "Failed to sign CertificateRequest, will retry: %s", err)
-			if didCustomConditionTransition {
-				// the reconciliation loop will be retriggered because of the added/ changed custom condition
-				return result, crStatusPatch, reconcile.TerminalError(err) // apply patch, done
-			} else {
-				return result, crStatusPatch, err // requeue with backoff, apply patch
-			}
-		}
-	}
-
-	crStatusPatch.Certificate = signedCertificate.ChainPEM
-	if r.SetCAOnCertificateRequest {
-		crStatusPatch.CA = signedCertificate.CAPEM
-	}
-	conditions.SetCertificateRequestStatusCondition(
-		r.Clock,
-		cr.Status.Conditions,
-		&crStatusPatch.Conditions,
-		cmapi.CertificateRequestConditionReady,
-		cmmeta.ConditionTrue,
-		cmapi.CertificateRequestReasonIssued,
-		"Succeeded signing the CertificateRequest",
-	)
-
-	logger.V(1).Info("Successfully finished the reconciliation.")
-	r.EventRecorder.Eventf(&cr, corev1.EventTypeNormal, "Issued", "Succeeded signing the CertificateRequest")
-	return result, crStatusPatch, nil // done, apply patch
-}
-
-func (r *CertificateRequestReconciler) setIssuersGroupVersionKind(scheme *runtime.Scheme) error {
-	for _, issuerType := range r.allIssuerTypes() {
-		if err := kubeutil.SetGroupVersionKind(scheme, issuerType); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (r *CertificateRequestReconciler) matchIssuerType(cr *cmapi.CertificateRequest) (v1alpha1.Issuer, types.NamespacedName, error) {
 	if cr == nil {
 		return nil, types.NamespacedName{}, fmt.Errorf("invalid reference, CertificateRequest is nil")
 	}
 
 	// Search for matching issuer
-	for i, issuerType := range r.allIssuerTypes() {
-		// The namespaced issuers are located in the first part of the array.
-		isNamespaced := i < len(r.IssuerTypes)
-		gvk := issuerType.GetObjectKind().GroupVersionKind()
+	for _, issuerType := range r.AllIssuerTypes() {
+		gvk := issuerType.Type.GetObjectKind().GroupVersionKind()
 
 		if (cr.Spec.IssuerRef.Group != gvk.Group) ||
 			(cr.Spec.IssuerRef.Kind != "" && cr.Spec.IssuerRef.Kind != gvk.Kind) {
@@ -415,11 +58,11 @@ func (r *CertificateRequestReconciler) matchIssuerType(cr *cmapi.CertificateRequ
 		}
 
 		namespace := ""
-		if isNamespaced {
+		if issuerType.IsNamespaced {
 			namespace = cr.Namespace
 		}
 
-		issuerObject := issuerType.DeepCopyObject().(v1alpha1.Issuer)
+		issuerObject := issuerType.Type.DeepCopyObject().(v1alpha1.Issuer)
 		issuerName := types.NamespacedName{
 			Name:      cr.Spec.IssuerRef.Name,
 			Namespace: namespace,
@@ -430,114 +73,33 @@ func (r *CertificateRequestReconciler) matchIssuerType(cr *cmapi.CertificateRequ
 	return nil, types.NamespacedName{}, fmt.Errorf("no issuer found for reference: [Group=%q, Kind=%q, Name=%q]", cr.Spec.IssuerRef.Group, cr.Spec.IssuerRef.Kind, cr.Spec.IssuerRef.Name)
 }
 
-func (r *CertificateRequestReconciler) allIssuerTypes() []v1alpha1.Issuer {
-	issuers := make([]v1alpha1.Issuer, 0, len(r.IssuerTypes)+len(r.ClusterIssuerTypes))
-	issuers = append(issuers, r.IssuerTypes...)
-	issuers = append(issuers, r.ClusterIssuerTypes...)
-	return issuers
+func (r *CertificateRequestReconciler) Init() *CertificateRequestReconciler {
+	r.RequestController.Init(
+		&cmapi.CertificateRequest{},
+		CertificateRequestPredicate{},
+		r.matchIssuerType,
+		func(o client.Object) RequestObjectHelper {
+			return &certificateRequestObjectHelper{
+				readOnlyObj:               o.(*cmapi.CertificateRequest),
+				setCAOnCertificateRequest: r.SetCAOnCertificateRequest,
+			}
+		},
+	)
+
+	return r
 }
 
-// SetupWithManager sets up the controller with the Manager.
-//
-// It ensures that the Manager scheme has all the types that are needed by this controller.
-// It sets up indexing of CertificateRequests by issuerRef to allow fast lookups
-// of all the CertificateRequest resources associated with a particular Issuer /
-// ClusterIssuer.
-// It configures the controller re-reconcile all the related CertificateRequests
-// when an Issuer / ClusterIssuer is created or when it changes. This ensures
-// that a CertificateRequest will be properly reconciled regardless of whether
-// the Issuer it references is created before or afterwards.
 func (r *CertificateRequestReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	if err := setupCertificateRequestReconcilerScheme(mgr.GetScheme()); err != nil {
 		return err
 	}
 
-	crType := &cmapi.CertificateRequest{}
-	if err := kubeutil.SetGroupVersionKind(mgr.GetScheme(), crType); err != nil {
-		return err
-	}
+	r.Init()
 
-	if err := r.setIssuersGroupVersionKind(mgr.GetScheme()); err != nil {
-		return err
-	}
-
-	build := ctrl.
-		NewControllerManagedBy(mgr).
-		For(
-			crType,
-			// We are only interested in changes to the non-ready conditions of the
-			// certificaterequest, this also prevents us to get in fast reconcile loop
-			// when setting the status to Pending causing the resource to update, while
-			// we only want to re-reconcile with backoff/ when a resource becomes available.
-			builder.WithPredicates(
-				predicate.ResourceVersionChangedPredicate{},
-				CertificateRequestPredicate{},
-			),
-		)
-
-	// We watch all the issuer types. When an issuer receives a watch event, we
-	// reconcile all the certificate requests that reference that issuer. This
-	// is useful when the certificate request undergoes long backoff retry
-	// periods and wouldn't react quickly to a fix in the issuer configuration.
-	for _, issuerType := range r.allIssuerTypes() {
-		issuerType := issuerType
-		gvk := issuerType.GetObjectKind().GroupVersionKind()
-
-		// This context is passed through to the client-go informer factory and the
-		// timeout dictates how long to wait for the informer to sync with the K8S
-		// API server. See:
-		// * https://github.com/kubernetes-sigs/controller-runtime/issues/562
-		// * https://github.com/kubernetes-sigs/controller-runtime/issues/1219
-		//
-		// The defaulting logic is based on:
-		// https://github.com/kubernetes-sigs/controller-runtime/blob/30eae58f1b984c1b8139dd9b9f68dd2d530ed429/pkg/controller/controller.go#L138-L144
-		timeout := mgr.GetControllerOptions().CacheSyncTimeout
-		if timeout == 0 {
-			timeout = 2 * time.Minute
-		}
-		cacheSyncCtx, cancel := context.WithTimeout(ctx, timeout)
-		defer cancel()
-
-		resourceHandler, err := kubeutil.NewLinkedResourceHandler(
-			cacheSyncCtx,
-			mgr.GetLogger(),
-			mgr.GetScheme(),
-			mgr.GetCache(),
-			&cmapi.CertificateRequest{},
-			func(rawObj client.Object) []string {
-				cr := rawObj.(*cmapi.CertificateRequest)
-
-				issuerObject, issuerName, err := r.matchIssuerType(cr)
-				if err != nil || issuerObject.GetObjectKind().GroupVersionKind() != gvk {
-					return nil
-				}
-
-				return []string{fmt.Sprintf("%s/%s", issuerName.Namespace, issuerName.Name)}
-			},
-			nil,
-		)
-		if err != nil {
-			return err
-		}
-
-		build = build.Watches(
-			issuerType,
-			resourceHandler,
-			builder.WithPredicates(
-				predicate.ResourceVersionChangedPredicate{},
-				LinkedIssuerPredicate{},
-			),
-		)
-	}
-
-	if controller, err := build.Build(r); err != nil {
-		return err
-	} else if r.PostSetupWithManager != nil {
-		err := r.PostSetupWithManager(ctx, crType.GroupVersionKind(), mgr, controller)
-		r.PostSetupWithManager = nil // free setup function
-		return err
-	}
-	return nil
+	return r.RequestController.SetupWithManager(
+		ctx,
+		mgr,
+	)
 }
 
 func setupCertificateRequestReconcilerScheme(scheme *runtime.Scheme) error {

--- a/controllers/certificatesigningrequest_controller.go
+++ b/controllers/certificatesigningrequest_controller.go
@@ -18,286 +18,21 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
-	"time"
 
-	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/util"
-	"github.com/go-logr/logr"
 	certificatesv1 "k8s.io/api/certificates/v1"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/clock"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1alpha1 "github.com/cert-manager/issuer-lib/api/v1alpha1"
-	"github.com/cert-manager/issuer-lib/conditions"
-	"github.com/cert-manager/issuer-lib/controllers/signer"
-	"github.com/cert-manager/issuer-lib/internal/kubeutil"
-	"github.com/cert-manager/issuer-lib/internal/ssaclient"
 )
 
 // CertificateSigningRequestReconciler reconciles a CertificateSigningRequest object
 type CertificateSigningRequestReconciler struct {
-	IssuerTypes        []v1alpha1.Issuer
-	ClusterIssuerTypes []v1alpha1.Issuer
-
-	FieldOwner       string
-	MaxRetryDuration time.Duration
-	EventSource      kubeutil.EventSource
-
-	// Client is a controller-runtime client used to get and set K8S API resources
-	client.Client
-	// Sign connects to a CA and returns a signed certificate for the supplied CertificateSigningRequest.
-	signer.Sign
-	// IgnoreCertificateSigningRequest is an optional function that can prevent the CertificateSigningRequest
-	// and Kubernetes CSR controllers from reconciling a CertificateSigningRequest resource.
-	signer.IgnoreCertificateRequest
-
-	// EventRecorder is used for creating Kubernetes events on resources.
-	EventRecorder record.EventRecorder
-
-	// Clock is used to mock condition transition times in tests.
-	Clock clock.PassiveClock
-
-	PostSetupWithManager func(context.Context, schema.GroupVersionKind, ctrl.Manager, controller.Controller) error
-}
-
-func (r *CertificateSigningRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, returnedError error) {
-	logger := log.FromContext(ctx).WithName("Reconcile")
-
-	logger.V(2).Info("Starting reconcile loop", "name", req.Name, "namespace", req.Namespace)
-
-	// The error returned by `reconcileStatusPatch` is meant for controller-runtime,
-	// not for us. That's why we aren't checking `reconcileError != nil` .
-	result, csrStatusPatch, returnedError := r.reconcileStatusPatch(logger, ctx, req)
-
-	logger.V(2).Info("Got StatusPatch result", "result", result, "patch", csrStatusPatch, "error", returnedError)
-
-	if csrStatusPatch != nil {
-		cr, patch, err := ssaclient.GenerateCertificateSigningRequestStatusPatch(req.Name, req.Namespace, csrStatusPatch)
-		if err != nil {
-			return ctrl.Result{}, utilerrors.NewAggregate([]error{err, returnedError})
-		}
-
-		if err := r.Client.Status().Patch(ctx, &cr, patch, &client.SubResourcePatchOptions{
-			PatchOptions: client.PatchOptions{
-				FieldManager: r.FieldOwner,
-				Force:        ptr.To(true),
-			},
-		}); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return ctrl.Result{}, utilerrors.NewAggregate([]error{err, returnedError})
-			}
-
-			logger.V(1).Info("Not found. Ignoring.")
-		}
-	}
-
-	return result, returnedError
-}
-
-// reconcileStatusPatch is responsible for reconciling the Kubernetes
-// CertificateSigningRequest resource. It will return the result and reconcileError
-// to be returned by the Reconcile function. It also returns a statusPatch that
-// the Reconcile function will apply to the request resource's status. This function
-// is split out from the Reconcile function to allow for easier testing.
-//
-// The error returned by `reconcileStatusPatch` is meant for controller-runtime,
-// not for the caller. The caller must not check the error (i.e., they must not
-// do `if err != nil...`).
-func (r *CertificateSigningRequestReconciler) reconcileStatusPatch(
-	logger logr.Logger,
-	ctx context.Context,
-	req ctrl.Request,
-) (result ctrl.Result, csrStatusPatch *certificatesv1.CertificateSigningRequestStatus, returnedError error) {
-	var csr certificatesv1.CertificateSigningRequest
-	if err := r.Client.Get(ctx, req.NamespacedName, &csr); err != nil && apierrors.IsNotFound(err) {
-		logger.V(1).Info("Not found. Ignoring.")
-		return result, nil, nil // done
-	} else if err != nil {
-		return result, nil, fmt.Errorf("unexpected get error: %v", err) // retry
-	}
-
-	// Ignore CertificateSigningRequest if it has not yet been assigned an approval
-	// status condition by an approval controller.
-	if !util.CertificateSigningRequestIsApproved(&csr) && !util.CertificateSigningRequestIsDenied(&csr) {
-		logger.V(1).Info("CertificateSigningRequest has not been approved or denied. Ignoring.")
-		return result, nil, nil // done
-	}
-
-	// Select first matching issuer type and construct an issuerObject and issuerName
-	issuerObject, issuerName, err := r.matchIssuerType(&csr)
-	// Ignore CertificateSigningRequest if issuerRef doesn't match one of our issuer Types
-	if err != nil {
-		logger.V(1).Info("Foreign issuer. Ignoring.", "error", err)
-		return result, nil, nil // done
-	}
-	issuerGvk := issuerObject.GetObjectKind().GroupVersionKind()
-
-	// Ignore CertificateSigningRequest if it is already Ready
-	if len(csr.Status.Certificate) > 0 {
-		logger.V(1).Info("CertificateSigningRequest is Ready. Ignoring.")
-		return result, nil, nil // done
-	}
-
-	// Ignore CertificateSigningRequest if it is already Failed
-	if util.CertificateSigningRequestIsFailed(&csr) {
-		logger.V(1).Info("CertificateSigningRequest is Failed. Ignoring.")
-		return result, nil, nil // done
-	}
-
-	// Ignore CertificateSigningRequest if it is Denied
-	if util.CertificateSigningRequestIsDenied(&csr) {
-		logger.V(1).Info("CertificateSigningRequest is Denied. Ignoring.")
-		return result, nil, nil // done
-	}
-
-	if r.IgnoreCertificateRequest != nil {
-		ignore, err := r.IgnoreCertificateRequest(ctx, signer.CertificateRequestObjectFromCertificateSigningRequest(&csr), issuerGvk, issuerName)
-		if err != nil {
-			return result, nil, fmt.Errorf("failed to check if CertificateSigningRequest should be ignored: %v", err) // retry
-		}
-		if ignore {
-			logger.V(1).Info("Ignoring CertificateSigningRequest")
-			return result, nil, nil // done
-		}
-	}
-
-	// We now have a CertificateSigningRequestStatus that belongs to us so we are responsible
-	// for updating its Status.
-	csrStatusPatch = &certificatesv1.CertificateSigningRequestStatus{}
-
-	if err := r.Client.Get(ctx, issuerName, issuerObject); err != nil && apierrors.IsNotFound(err) {
-		logger.V(1).Info("Issuer not found. Waiting for it to be created")
-		r.EventRecorder.Eventf(&csr, corev1.EventTypeNormal, "WaitingForIssuerExist", fmt.Sprintf("%s. Waiting for it to be created.", err))
-		return result, csrStatusPatch, nil // done, apply patch
-	} else if err != nil {
-		r.EventRecorder.Eventf(&csr, corev1.EventTypeWarning, "UnexpectedError", "Got an unexpected error while processing the CR")
-		return result, nil, fmt.Errorf("unexpected get error: %v", err) // retry
-	}
-
-	readyCondition := conditions.GetIssuerStatusCondition(
-		issuerObject.GetStatus().Conditions,
-		cmapi.IssuerConditionReady,
-	)
-	if (readyCondition == nil) ||
-		(readyCondition.Status != cmmeta.ConditionTrue) ||
-		(readyCondition.ObservedGeneration < issuerObject.GetGeneration()) {
-
-		message := ""
-		if readyCondition == nil {
-			message = "Waiting for issuer to become ready. Current issuer ready condition: <none>."
-		} else if readyCondition.Status != cmmeta.ConditionTrue {
-			message = fmt.Sprintf("Waiting for issuer to become ready. Current issuer ready condition is \"%s\": %s.", readyCondition.Reason, readyCondition.Message)
-		} else {
-			message = "Waiting for issuer to become ready. Current issuer ready condition is outdated."
-		}
-
-		logger.V(1).Info("Issuer is not Ready yet. Waiting for it to become ready.", "issuer ready condition", readyCondition)
-		r.EventRecorder.Eventf(&csr, corev1.EventTypeNormal, "WaitingForIssuerReady", message)
-		return result, csrStatusPatch, nil // done, apply patch
-	}
-
-	signedCertificate, err := r.Sign(log.IntoContext(ctx, logger), signer.CertificateRequestObjectFromCertificateSigningRequest(&csr), issuerObject)
-	if err != nil {
-		// An error in the issuer part of the operator should trigger a reconcile
-		// of the issuer's state.
-		if issuerError := new(signer.IssuerError); errors.As(err, issuerError) {
-			if reportError := r.EventSource.ReportError(
-				issuerGvk, client.ObjectKeyFromObject(issuerObject),
-				issuerError.Err,
-			); reportError != nil {
-				err = utilerrors.NewAggregate([]error{err, reportError})
-			}
-
-			logger.V(1).Error(err, "Temporary CertificateSigningRequest error.")
-
-			r.EventRecorder.Eventf(&csr, corev1.EventTypeWarning, "WaitingForIssuerReady", "Waiting for issuer to become ready. Current issuer ready condition is outdated.")
-			return result, csrStatusPatch, reconcile.TerminalError(err) // done, apply patch
-		}
-
-		didCustomConditionTransition := false
-
-		if targetCustom := new(signer.SetCertificateRequestConditionError); errors.As(err, targetCustom) {
-			logger.V(1).Info("Set CertificateSigningRequestCondition error. Setting condition.", "error", err)
-			conditions.SetCertificateSigningRequestStatusCondition(
-				r.Clock,
-				csr.Status.Conditions,
-				&csrStatusPatch.Conditions,
-				certificatesv1.RequestConditionType(targetCustom.ConditionType),
-				corev1.ConditionStatus(targetCustom.Status),
-				targetCustom.Reason,
-				targetCustom.Error(),
-			)
-
-			// check if the custom condition transitioned
-			currentCustom := conditions.GetCertificateSigningRequestStatusCondition(csr.Status.Conditions, certificatesv1.RequestConditionType(targetCustom.ConditionType))
-			didCustomConditionTransition = currentCustom == nil || currentCustom.Status != corev1.ConditionStatus(targetCustom.Status)
-		}
-
-		// Check if we have still time to requeue & retry
-		isPendingError := errors.As(err, &signer.PendingError{})
-		isPermanentError := errors.As(err, &signer.PermanentError{})
-		pastMaxRetryDuration := r.Clock.Now().After(csr.CreationTimestamp.Add(r.MaxRetryDuration))
-		if !isPendingError && (isPermanentError || pastMaxRetryDuration) {
-			// fail permanently
-			logger.V(1).Error(err, "Permanent CertificateSigningRequest error. Marking as failed.")
-
-			conditions.SetCertificateSigningRequestStatusCondition(
-				r.Clock,
-				csr.Status.Conditions,
-				&csrStatusPatch.Conditions,
-				certificatesv1.CertificateFailed,
-				corev1.ConditionTrue,
-				cmapi.CertificateRequestReasonFailed,
-				fmt.Sprintf("CertificateSigningRequest has failed permanently: %s", err),
-			)
-			r.EventRecorder.Eventf(&csr, corev1.EventTypeWarning, "PermanentError", "CertificateSigningRequest has failed permanently: %s", err)
-			return result, csrStatusPatch, reconcile.TerminalError(err) // done, apply patch
-		} else {
-			// retry
-			logger.V(1).Error(err, "Retryable CertificateSigningRequest error.")
-
-			r.EventRecorder.Eventf(&csr, corev1.EventTypeWarning, "RetryableError", "Failed to sign CertificateSigningRequest, will retry: %s", err)
-			if didCustomConditionTransition {
-				// the reconciliation loop will be retriggered because of the added/ changed custom condition
-				return result, csrStatusPatch, reconcile.TerminalError(err) // apply patch, done
-			} else {
-				return result, csrStatusPatch, err // requeue with backoff, apply patch
-			}
-		}
-	}
-
-	csrStatusPatch.Certificate = signedCertificate.ChainPEM
-
-	logger.V(1).Info("Successfully finished the reconciliation.")
-	r.EventRecorder.Eventf(&csr, corev1.EventTypeNormal, "Issued", "Succeeded signing the CertificateSigningRequest")
-	return result, csrStatusPatch, nil // done, apply patch
-}
-
-func (r *CertificateSigningRequestReconciler) setIssuersGroupVersionKind(scheme *runtime.Scheme) error {
-	for _, issuerType := range r.allIssuerTypes() {
-		if err := kubeutil.SetGroupVersionKind(scheme, issuerType); err != nil {
-			return err
-		}
-	}
-	return nil
+	RequestController
 }
 
 // matchIssuerType returns the IssuerType and IssuerName that matches the
@@ -307,7 +42,9 @@ func (r *CertificateSigningRequestReconciler) setIssuersGroupVersionKind(scheme 
 // "<issuer-type-id>/<issuer-id>". The issuer-type-id is obtained from the
 // GetIssuerTypeIdentifier function of the IssuerType.
 // The issuer-id is "<name>" for a ClusterIssuer resource.
-func (r *CertificateSigningRequestReconciler) matchIssuerType(csr *certificatesv1.CertificateSigningRequest) (v1alpha1.Issuer, types.NamespacedName, error) {
+func (r *CertificateSigningRequestReconciler) matchIssuerType(requestObject client.Object) (v1alpha1.Issuer, types.NamespacedName, error) {
+	csr := requestObject.(*certificatesv1.CertificateSigningRequest)
+
 	if csr == nil {
 		return nil, types.NamespacedName{}, fmt.Errorf("invalid signer name, should have format <issuer-type-id>/<issuer-id>")
 	}
@@ -321,21 +58,18 @@ func (r *CertificateSigningRequestReconciler) matchIssuerType(csr *certificatesv
 	issuerIdentifier := split[1]
 
 	// Search for matching issuer
-	for i, issuerType := range r.allIssuerTypes() {
-		// The namespaced issuers are located in the first part of the array.
-		isNamespaced := i < len(r.IssuerTypes)
-
-		if issuerTypeIdentifier != issuerType.GetIssuerTypeIdentifier() {
+	for _, issuerType := range r.AllIssuerTypes() {
+		if issuerTypeIdentifier != issuerType.Type.GetIssuerTypeIdentifier() {
 			continue
 		}
 
-		issuerObject := issuerType.DeepCopyObject().(v1alpha1.Issuer)
+		issuerObject := issuerType.Type.DeepCopyObject().(v1alpha1.Issuer)
 
 		issuerName := types.NamespacedName{
 			Name: issuerIdentifier,
 		}
 
-		if isNamespaced {
+		if issuerType.IsNamespaced {
 			return nil, types.NamespacedName{}, fmt.Errorf("invalid SignerName, %q is a namespaced issuer type, namespaced issuers are not supported for Kubernetes CSRs", issuerTypeIdentifier)
 		}
 
@@ -345,114 +79,33 @@ func (r *CertificateSigningRequestReconciler) matchIssuerType(csr *certificatesv
 	return nil, types.NamespacedName{}, fmt.Errorf("no issuer found for signer name: %q", csr.Spec.SignerName)
 }
 
-func (r *CertificateSigningRequestReconciler) allIssuerTypes() []v1alpha1.Issuer {
-	issuers := make([]v1alpha1.Issuer, 0, len(r.IssuerTypes)+len(r.ClusterIssuerTypes))
-	issuers = append(issuers, r.IssuerTypes...)
-	issuers = append(issuers, r.ClusterIssuerTypes...)
-	return issuers
+func (r *CertificateSigningRequestReconciler) Init() *CertificateSigningRequestReconciler {
+	r.RequestController.Init(
+		&certificatesv1.CertificateSigningRequest{},
+		CertificateSigningRequestPredicate{},
+		r.matchIssuerType,
+		func(o client.Object) RequestObjectHelper {
+			return &certificatesigningRequestObjectHelper{
+				readOnlyObj: o.(*certificatesv1.CertificateSigningRequest),
+			}
+		},
+	)
+
+	return r
 }
 
 // SetupWithManager sets up the controller with the Manager.
-//
-// It ensures that the Manager scheme has all the types that are needed by this controller.
-// It sets up indexing of CertificateSigningRequests by issuerRef to allow fast lookups
-// of all the CertificateSigningRequest resources associated with a particular Issuer /
-// ClusterIssuer.
-// It configures the controller re-reconcile all the related CertificateSigningRequests
-// when an Issuer / ClusterIssuer is created or when it changes. This ensures
-// that a CertificateSigningRequest will be properly reconciled regardless of whether
-// the Issuer it references is created before or afterwards.
 func (r *CertificateSigningRequestReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	if err := setupCertificateSigningRequestReconcilerScheme(mgr.GetScheme()); err != nil {
 		return err
 	}
 
-	crType := &certificatesv1.CertificateSigningRequest{}
-	if err := kubeutil.SetGroupVersionKind(mgr.GetScheme(), crType); err != nil {
-		return err
-	}
+	r.Init()
 
-	if err := r.setIssuersGroupVersionKind(mgr.GetScheme()); err != nil {
-		return err
-	}
-
-	build := ctrl.
-		NewControllerManagedBy(mgr).
-		For(
-			crType,
-			// We are only interested in changes to the non-ready conditions of the
-			// certificaterequest, this also prevents us to get in fast reconcile loop
-			// when setting the status to Pending causing the resource to update, while
-			// we only want to re-reconcile with backoff/ when a resource becomes available.
-			builder.WithPredicates(
-				predicate.ResourceVersionChangedPredicate{},
-				CertificateSigningRequestPredicate{},
-			),
-		)
-
-	// We watch all the issuer types. When an issuer receives a watch event, we
-	// reconcile all the certificate requests that reference that issuer. This
-	// is useful when the certificate request undergoes long backoff retry
-	// periods and wouldn't react quickly to a fix in the issuer configuration.
-	for _, issuerType := range r.allIssuerTypes() {
-		issuerType := issuerType
-		gvk := issuerType.GetObjectKind().GroupVersionKind()
-
-		// This context is passed through to the client-go informer factory and the
-		// timeout dictates how long to wait for the informer to sync with the K8S
-		// API server. See:
-		// * https://github.com/kubernetes-sigs/controller-runtime/issues/562
-		// * https://github.com/kubernetes-sigs/controller-runtime/issues/1219
-		//
-		// The defaulting logic is based on:
-		// https://github.com/kubernetes-sigs/controller-runtime/blob/30eae58f1b984c1b8139dd9b9f68dd2d530ed429/pkg/controller/controller.go#L138-L144
-		timeout := mgr.GetControllerOptions().CacheSyncTimeout
-		if timeout == 0 {
-			timeout = 2 * time.Minute
-		}
-		cacheSyncCtx, cancel := context.WithTimeout(ctx, timeout)
-		defer cancel()
-
-		resourceHandler, err := kubeutil.NewLinkedResourceHandler(
-			cacheSyncCtx,
-			mgr.GetLogger(),
-			mgr.GetScheme(),
-			mgr.GetCache(),
-			&certificatesv1.CertificateSigningRequest{},
-			func(rawObj client.Object) []string {
-				csr := rawObj.(*certificatesv1.CertificateSigningRequest)
-
-				issuerObject, issuerName, err := r.matchIssuerType(csr)
-				if err != nil || issuerObject.GetObjectKind().GroupVersionKind() != gvk {
-					return nil
-				}
-
-				return []string{fmt.Sprintf("%s/%s", issuerName.Namespace, issuerName.Name)}
-			},
-			nil,
-		)
-		if err != nil {
-			return err
-		}
-
-		build = build.Watches(
-			issuerType,
-			resourceHandler,
-			builder.WithPredicates(
-				predicate.ResourceVersionChangedPredicate{},
-				LinkedIssuerPredicate{},
-			),
-		)
-	}
-
-	if controller, err := build.Build(r); err != nil {
-		return err
-	} else if r.PostSetupWithManager != nil {
-		err := r.PostSetupWithManager(ctx, crType.GroupVersionKind(), mgr, controller)
-		r.PostSetupWithManager = nil // free setup function
-		return err
-	}
-	return nil
+	return r.RequestController.SetupWithManager(
+		ctx,
+		mgr,
+	)
 }
 
 func setupCertificateSigningRequestReconcilerScheme(scheme *runtime.Scheme) error {

--- a/controllers/combined_controller.go
+++ b/controllers/combined_controller.go
@@ -118,22 +118,24 @@ func (r *CombinedController) SetupWithManager(ctx context.Context, mgr ctrl.Mana
 
 	if !r.DisableCertificateRequestController {
 		if err = (&CertificateRequestReconciler{
-			IssuerTypes:        r.IssuerTypes,
-			ClusterIssuerTypes: r.ClusterIssuerTypes,
+			RequestController: RequestController{
+				IssuerTypes:        r.IssuerTypes,
+				ClusterIssuerTypes: r.ClusterIssuerTypes,
 
-			FieldOwner:       r.FieldOwner,
-			MaxRetryDuration: r.MaxRetryDuration,
-			EventSource:      eventSource,
+				FieldOwner:       r.FieldOwner,
+				MaxRetryDuration: r.MaxRetryDuration,
+				EventSource:      eventSource,
 
-			Client:                   cl,
-			Sign:                     r.Sign,
-			IgnoreCertificateRequest: r.IgnoreCertificateRequest,
-			EventRecorder:            r.EventRecorder,
-			Clock:                    r.Clock,
+				Client:                   cl,
+				Sign:                     r.Sign,
+				IgnoreCertificateRequest: r.IgnoreCertificateRequest,
+				EventRecorder:            r.EventRecorder,
+				Clock:                    r.Clock,
+
+				PostSetupWithManager: r.PostSetupWithManager,
+			},
 
 			SetCAOnCertificateRequest: r.SetCAOnCertificateRequest,
-
-			PostSetupWithManager: r.PostSetupWithManager,
 		}).SetupWithManager(ctx, mgr); err != nil {
 			return fmt.Errorf("CertificateRequestReconciler: %w", err)
 		}
@@ -141,20 +143,22 @@ func (r *CombinedController) SetupWithManager(ctx context.Context, mgr ctrl.Mana
 
 	if !r.DisableKubernetesCSRController {
 		if err = (&CertificateSigningRequestReconciler{
-			IssuerTypes:        r.IssuerTypes,
-			ClusterIssuerTypes: r.ClusterIssuerTypes,
+			RequestController: RequestController{
+				IssuerTypes:        r.IssuerTypes,
+				ClusterIssuerTypes: r.ClusterIssuerTypes,
 
-			FieldOwner:       r.FieldOwner,
-			MaxRetryDuration: r.MaxRetryDuration,
-			EventSource:      eventSource,
+				FieldOwner:       r.FieldOwner,
+				MaxRetryDuration: r.MaxRetryDuration,
+				EventSource:      eventSource,
 
-			Client:                   cl,
-			Sign:                     r.Sign,
-			IgnoreCertificateRequest: r.IgnoreCertificateRequest,
-			EventRecorder:            r.EventRecorder,
-			Clock:                    r.Clock,
+				Client:                   cl,
+				Sign:                     r.Sign,
+				IgnoreCertificateRequest: r.IgnoreCertificateRequest,
+				EventRecorder:            r.EventRecorder,
+				Clock:                    r.Clock,
 
-			PostSetupWithManager: r.PostSetupWithManager,
+				PostSetupWithManager: r.PostSetupWithManager,
+			},
 		}).SetupWithManager(ctx, mgr); err != nil {
 			return fmt.Errorf("CertificateRequestReconciler: %w", err)
 		}

--- a/controllers/request_controller.go
+++ b/controllers/request_controller.go
@@ -1,0 +1,462 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1alpha1 "github.com/cert-manager/issuer-lib/api/v1alpha1"
+	"github.com/cert-manager/issuer-lib/conditions"
+	"github.com/cert-manager/issuer-lib/controllers/signer"
+	"github.com/cert-manager/issuer-lib/internal/kubeutil"
+)
+
+// RequestController reconciles a "request" object.
+// A request object implementation can be provided using the requestObjectHelperCreator
+// function. This function is responsible for creating a RequestObjectHelper that
+// is used to interact with the request object.
+// Currently, we support cert-manager CertificateRequests and Kubernetes CertificateSigningRequests.
+type RequestController struct {
+	IssuerTypes        []v1alpha1.Issuer
+	ClusterIssuerTypes []v1alpha1.Issuer
+
+	FieldOwner       string
+	MaxRetryDuration time.Duration
+	EventSource      kubeutil.EventSource
+
+	// Client is a controller-runtime client used to get and set K8S API resources
+	client.Client
+	// Sign connects to a CA and returns a signed certificate for the supplied Request.
+	signer.Sign
+	// IgnoreCertificateRequest is an optional function that can prevent the Request
+	// and Kubernetes CSR controllers from reconciling a Request resource.
+	signer.IgnoreCertificateRequest
+
+	// EventRecorder is used for creating Kubernetes events on resources.
+	EventRecorder record.EventRecorder
+
+	// Clock is used to mock condition transition times in tests.
+	Clock clock.PassiveClock
+
+	PostSetupWithManager func(context.Context, schema.GroupVersionKind, ctrl.Manager, controller.Controller) error
+
+	allIssuerTypes []IssuerType
+
+	initialised                bool
+	requestType                client.Object
+	requestPredicate           predicate.Predicate
+	matchIssuerType            MatchIssuerType
+	requestObjectHelperCreator RequestObjectHelperCreator
+}
+
+type MatchIssuerType func(client.Object) (v1alpha1.Issuer, client.ObjectKey, error)
+type RequestObjectHelperCreator func(client.Object) RequestObjectHelper
+
+type IssuerType struct {
+	Type         v1alpha1.Issuer
+	IsNamespaced bool
+}
+
+func (r *RequestController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithName("Reconcile")
+
+	logger.V(2).Info("Starting reconcile loop", "name", req.Name, "namespace", req.Namespace)
+
+	// The error returned by `reconcileStatusPatch` is meant for controller-runtime,
+	// not for us. That's why we aren't checking `reconcileError != nil` .
+	result, statusPatch, reconcileError := r.reconcileStatusPatch(logger, ctx, req)
+
+	if statusPatch != nil {
+		obj, patch, err := statusPatch.Patch()
+		if err != nil {
+			return ctrl.Result{}, utilerrors.NewAggregate([]error{err, reconcileError}) // requeue with backoff
+		}
+
+		logger.V(2).Info("Got StatusPatch result", "result", result, "error", reconcileError, "patch", patch)
+
+		if err := r.Client.Status().Patch(ctx, obj, patch, &client.SubResourcePatchOptions{
+			PatchOptions: client.PatchOptions{
+				FieldManager: r.FieldOwner,
+				Force:        ptr.To(true),
+			},
+		}); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, utilerrors.NewAggregate([]error{err, reconcileError}) // requeue with backoff
+			}
+
+			logger.V(1).Info("Request not found. Ignoring.")
+		}
+	} else {
+		logger.V(2).Info("Got nil StatusPatch result", "result", result, "error", reconcileError)
+	}
+
+	return result, reconcileError
+}
+
+// reconcileStatusPatch is responsible for reconciling the request resource (cert-manager
+// CertificateRequest or Kubernetes CertificateSigningRequest). It will return the
+// result and reconcileError to be returned by the Reconcile function. It also returns
+// a statusPatch that the Reconcile function will apply to the request resource's status.
+// This function is split out from the Reconcile function to allow for easier testing.
+//
+// The error returned by `reconcileStatusPatch` is meant for controller-runtime,
+// not for the caller. The caller must not check the error (i.e., they must not
+// do `if err != nil...`).
+func (r *RequestController) reconcileStatusPatch(
+	logger logr.Logger,
+	ctx context.Context,
+	req ctrl.Request,
+) (result ctrl.Result, _ RequestPatch, reconcileError error) {
+	requestObject := r.requestType.DeepCopyObject().(client.Object)
+
+	if err := r.Client.Get(ctx, req.NamespacedName, requestObject); err != nil && apierrors.IsNotFound(err) {
+		logger.V(1).Info("Request not found. Ignoring.")
+		return result, nil, nil // done
+	} else if err != nil {
+		return result, nil, fmt.Errorf("unexpected get error: %v", err) // requeue with backoff
+	}
+
+	// Select first matching issuer type and construct an issuerObject and issuerName
+	issuerObject, issuerName, err := r.matchIssuerType(requestObject)
+	// Ignore Request if issuerRef doesn't match one of our issuer Types
+	if err != nil {
+		logger.V(1).Info("Request has a foreign issuer. Ignoring.", "error", err)
+		return result, nil, nil // done
+	}
+	issuerGvk := issuerObject.GetObjectKind().GroupVersionKind()
+
+	// Create a helper for the requestObject
+	requestObjectHelper := r.requestObjectHelperCreator(requestObject)
+
+	// Ignore Request if it has not yet been assigned an approval
+	// status condition by an approval controller.
+	if !requestObjectHelper.IsApproved() && !requestObjectHelper.IsDenied() {
+		logger.V(1).Info("Request has not been approved or denied. Ignoring.")
+		return result, nil, nil // done
+	}
+
+	// Ignore Request if it is already Ready
+	if requestObjectHelper.IsReady() {
+		logger.V(1).Info("Request is Ready. Ignoring.")
+		return result, nil, nil // done
+	}
+
+	// Ignore Request if it is already Failed
+	if requestObjectHelper.IsFailed() {
+		logger.V(1).Info("Request is Failed. Ignoring.")
+		return result, nil, nil // done
+	}
+
+	// Ignore Request if it is already Denied
+	if requestObjectHelper.IsDenied() {
+		logger.V(1).Info("Request is Denied. Ignoring.")
+		return result, nil, nil // done
+	}
+
+	if r.IgnoreCertificateRequest != nil {
+		ignore, err := r.IgnoreCertificateRequest(
+			ctx,
+			requestObjectHelper.RequestObject(),
+			issuerGvk,
+			issuerName,
+		)
+		if err != nil {
+			logger.V(1).Error(err, "Unexpected error while checking if Request should be ignored")
+			return result, nil, fmt.Errorf("failed to check if Request should be ignored: %v", err) // requeue with backoff
+		}
+
+		if ignore {
+			logger.V(1).Info("Ignoring Request")
+			return result, nil, nil // done
+		}
+	}
+
+	// We now have a Request that belongs to us so we are responsible
+	// for updating its Status.
+	statusPatch := requestObjectHelper.NewPatch(
+		r.Clock,
+		r.FieldOwner,
+		r.EventRecorder,
+	)
+
+	// Add a Ready condition if one does not already exist. Set initial Status
+	// to Unknown.
+	if statusPatch.SetInitializing() {
+		logger.V(1).Info("Initialised Ready condition")
+
+		// To continue reconciling this Request, we must re-run the reconcile loop
+		// after adding the Unknown Ready condition. This update will trigger a
+		// new reconcile loop, so we don't need to requeue here.
+		return result, statusPatch, nil // apply patch, done
+	}
+
+	if err := r.Client.Get(ctx, issuerName, issuerObject); err != nil && apierrors.IsNotFound(err) {
+		logger.V(1).Info("Issuer not found. Waiting for it to be created")
+		statusPatch.SetWaitingForIssuerExist(err)
+
+		return result, statusPatch, nil // apply patch, done
+	} else if err != nil {
+		logger.V(1).Error(err, "Unexpected error while getting Issuer")
+		statusPatch.SetUnexpectedError(err)
+
+		return result, nil, fmt.Errorf("unexpected get error: %v", err) // requeue with backoff
+	}
+
+	readyCondition := conditions.GetIssuerStatusCondition(
+		issuerObject.GetStatus().Conditions,
+		cmapi.IssuerConditionReady,
+	)
+	if readyCondition == nil {
+		logger.V(1).Info("Issuer is not Ready yet (no ready condition). Waiting for it to become ready.")
+		statusPatch.SetWaitingForIssuerReadyNoCondition()
+
+		return result, statusPatch, nil // apply patch, done
+	}
+	if readyCondition.ObservedGeneration < issuerObject.GetGeneration() {
+		logger.V(1).Info("Issuer is not Ready yet (ready condition out-of-date). Waiting for it to become ready.", "issuer ready condition", readyCondition)
+		statusPatch.SetWaitingForIssuerReadyOutdated()
+
+		return result, statusPatch, nil // apply patch, done
+	}
+	if readyCondition.Status != cmmeta.ConditionTrue {
+		logger.V(1).Info("Issuer is not Ready yet (status == false). Waiting for it to become ready.", "issuer ready condition", readyCondition)
+		statusPatch.SetWaitingForIssuerReadyNotReady(readyCondition)
+
+		return result, statusPatch, nil // apply patch, done
+	}
+
+	signedCertificate, err := r.Sign(log.IntoContext(ctx, logger), requestObjectHelper.RequestObject(), issuerObject)
+	if err == nil {
+		logger.V(1).Info("Successfully finished the reconciliation.")
+		statusPatch.SetIssued(signedCertificate)
+
+		return result, statusPatch, nil // apply patch, done
+	}
+
+	// An error in the issuer part of the operator should trigger a reconcile
+	// of the issuer's state.
+	if issuerError := new(signer.IssuerError); errors.As(err, issuerError) {
+		if reportError := r.EventSource.ReportError(
+			issuerGvk, client.ObjectKeyFromObject(issuerObject),
+			issuerError.Err,
+		); reportError != nil {
+			return result, nil, fmt.Errorf("unexpected ReportError error: %v", reportError) // requeue with backoff
+		}
+
+		logger.V(1).Info("Issuer is not Ready yet (ready condition out-of-date). Waiting for it to become ready.", "issuer-error", issuerError)
+		statusPatch.SetWaitingForIssuerReadyOutdated()
+
+		return result, statusPatch, nil // apply patch, done
+	}
+
+	didCustomConditionTransition := false
+	if targetCustom := new(signer.SetCertificateRequestConditionError); errors.As(err, targetCustom) {
+		logger.V(1).Info("Set RequestCondition error. Setting condition.", "error", err)
+		didCustomConditionTransition = statusPatch.SetCustomCondition(
+			string(targetCustom.ConditionType),
+			metav1.ConditionStatus(targetCustom.Status),
+			targetCustom.Reason,
+			targetCustom.Error(),
+		)
+	}
+
+	// Check if we have still time to requeue & retry
+	isPendingError := errors.As(err, &signer.PendingError{})
+	isPermanentError := errors.As(err, &signer.PermanentError{})
+	pastMaxRetryDuration := r.Clock.Now().After(requestObject.GetCreationTimestamp().Add(r.MaxRetryDuration))
+	if !isPendingError && (isPermanentError || pastMaxRetryDuration) {
+		// fail permanently
+		logger.V(1).Error(err, "Permanent Request error. Marking as failed.")
+		statusPatch.SetPermanentError(err)
+
+		return result, statusPatch, reconcile.TerminalError(err) // apply patch, done
+	} else {
+		// retry
+		logger.V(1).Error(err, "Retryable Request error.")
+		statusPatch.SetRetryableError(err)
+
+		if didCustomConditionTransition {
+			// the reconciliation loop will be retriggered because of the added/ changed custom condition
+			return result, statusPatch, reconcile.TerminalError(err) // apply patch, done
+		} else {
+			return result, statusPatch, err // apply patch, requeue with backoff
+		}
+	}
+}
+
+func (r *RequestController) setAllIssuerTypesWithGroupVersionKind(scheme *runtime.Scheme) error {
+	issuers := make([]IssuerType, 0, len(r.IssuerTypes)+len(r.ClusterIssuerTypes))
+	for _, issuer := range r.IssuerTypes {
+		issuers = append(issuers, IssuerType{
+			Type:         issuer,
+			IsNamespaced: true,
+		})
+
+	}
+	for _, issuer := range r.ClusterIssuerTypes {
+		issuers = append(issuers, IssuerType{
+			Type:         issuer,
+			IsNamespaced: false,
+		})
+	}
+
+	for _, issuer := range issuers {
+		if err := kubeutil.SetGroupVersionKind(scheme, issuer.Type); err != nil {
+			return err
+		}
+	}
+
+	r.allIssuerTypes = issuers
+
+	return nil
+}
+
+func (r *RequestController) AllIssuerTypes() []IssuerType {
+	return r.allIssuerTypes
+}
+
+func (r *RequestController) Init(
+	requestType client.Object,
+	requestPredicate predicate.Predicate,
+	matchIssuerType MatchIssuerType,
+	requestObjectHelperCreator RequestObjectHelperCreator,
+) *RequestController {
+	r.requestType = requestType
+	r.requestPredicate = requestPredicate
+	r.matchIssuerType = matchIssuerType
+	r.requestObjectHelperCreator = requestObjectHelperCreator
+
+	r.initialised = true
+
+	return r
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *RequestController) SetupWithManager(
+	ctx context.Context,
+	mgr ctrl.Manager,
+) error {
+	if !r.initialised {
+		return fmt.Errorf("must call Init(...) before calling SetupWithManager(...)")
+	}
+
+	if err := kubeutil.SetGroupVersionKind(mgr.GetScheme(), r.requestType); err != nil {
+		return err
+	}
+
+	if err := r.setAllIssuerTypesWithGroupVersionKind(mgr.GetScheme()); err != nil {
+		return err
+	}
+
+	build := ctrl.
+		NewControllerManagedBy(mgr).
+		For(
+			r.requestType,
+			// We are only interested in changes to the non-ready conditions of the
+			// certificaterequest, this also prevents us to get in fast reconcile loop
+			// when setting the status to Pending causing the resource to update, while
+			// we only want to re-reconcile with backoff/ when a resource becomes available.
+			builder.WithPredicates(
+				predicate.ResourceVersionChangedPredicate{},
+				r.requestPredicate,
+			),
+		)
+
+	// We watch all the issuer types. When an issuer receives a watch event, we
+	// reconcile all the certificate requests that reference that issuer. This
+	// is useful when the certificate request undergoes long backoff retry
+	// periods and wouldn't react quickly to a fix in the issuer configuration.
+	for _, issuerType := range r.AllIssuerTypes() {
+		issuerType := issuerType
+		gvk := issuerType.Type.GetObjectKind().GroupVersionKind()
+
+		// This context is passed through to the client-go informer factory and the
+		// timeout dictates how long to wait for the informer to sync with the K8S
+		// API server. See:
+		// * https://github.com/kubernetes-sigs/controller-runtime/issues/562
+		// * https://github.com/kubernetes-sigs/controller-runtime/issues/1219
+		//
+		// The defaulting logic is based on:
+		// https://github.com/kubernetes-sigs/controller-runtime/blob/30eae58f1b984c1b8139dd9b9f68dd2d530ed429/pkg/controller/controller.go#L138-L144
+		timeout := mgr.GetControllerOptions().CacheSyncTimeout
+		if timeout == 0 {
+			timeout = 2 * time.Minute
+		}
+		cacheSyncCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		resourceHandler, err := kubeutil.NewLinkedResourceHandler(
+			cacheSyncCtx,
+			mgr.GetLogger(),
+			mgr.GetScheme(),
+			mgr.GetCache(),
+			r.requestType,
+			func(rawObj client.Object) []string {
+				issuerObject, issuerName, err := r.matchIssuerType(rawObj)
+				if err != nil || issuerObject.GetObjectKind().GroupVersionKind() != gvk {
+					return nil
+				}
+
+				return []string{fmt.Sprintf("%s/%s", issuerName.Namespace, issuerName.Name)}
+			},
+			nil,
+		)
+		if err != nil {
+			return err
+		}
+
+		build = build.Watches(
+			issuerType.Type,
+			resourceHandler,
+			builder.WithPredicates(
+				predicate.ResourceVersionChangedPredicate{},
+				LinkedIssuerPredicate{},
+			),
+		)
+	}
+
+	if controller, err := build.Build(r); err != nil {
+		return err
+	} else if r.PostSetupWithManager != nil {
+		err := r.PostSetupWithManager(ctx, r.requestType.GetObjectKind().GroupVersionKind(), mgr, controller)
+		r.PostSetupWithManager = nil // free setup function
+		return err
+	}
+	return nil
+}

--- a/controllers/request_objecthelper.go
+++ b/controllers/request_objecthelper.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cert-manager/issuer-lib/controllers/signer"
+)
+
+const (
+	eventRequestIssued = "Issued"
+
+	eventRequestUnexpectedError = "UnexpectedError"
+	eventRequestRetryableError  = "RetryableError"
+	eventRequestPermanentError  = "PermanentError"
+
+	eventRequestWaitingForIssuerExist = "WaitingForIssuerExist"
+	eventRequestWaitingForIssuerReady = "WaitingForIssuerReady"
+)
+
+type RequestObjectHelper interface {
+	IsApproved() bool
+	IsDenied() bool
+	IsReady() bool
+	IsFailed() bool
+
+	RequestObject() signer.CertificateRequestObject
+
+	NewPatch(
+		clock clock.PassiveClock,
+		fieldOwner string,
+		eventRecorder record.EventRecorder,
+	) RequestPatchHelper
+}
+
+type RequestPatchHelper interface { //nolint:interfacebloat
+	RequestPatch
+
+	SetInitializing() (didInitialise bool)
+	SetWaitingForIssuerExist(error)
+	SetWaitingForIssuerReadyNoCondition()
+	SetWaitingForIssuerReadyOutdated()
+	SetWaitingForIssuerReadyNotReady(*cmapi.IssuerCondition)
+	SetCustomCondition(
+		conditionType string,
+		conditionStatus metav1.ConditionStatus,
+		conditionReason string, conditionMessage string,
+	) (didCustomConditionTransition bool)
+	SetRetryableError(error)
+	SetPermanentError(error)
+	SetUnexpectedError(error)
+	SetIssued(signer.PEMBundle)
+}
+
+type RequestPatch interface {
+	Patch() (client.Object, client.Patch, error)
+}
+
+type CertificateRequestPatch interface {
+	CertificateRequestPatch() *cmapi.CertificateRequestStatus
+}
+
+type CertificateSigningRequestPatch interface {
+	CertificateSigningRequestPatch() *certificatesv1.CertificateSigningRequestStatus
+}

--- a/controllers/request_objecthelper_certificaterequest.go
+++ b/controllers/request_objecthelper_certificaterequest.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+
+	cmutil "github.com/cert-manager/cert-manager/pkg/api/util"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/cert-manager/issuer-lib/api/v1alpha1"
+	"github.com/cert-manager/issuer-lib/conditions"
+	"github.com/cert-manager/issuer-lib/controllers/signer"
+	"github.com/cert-manager/issuer-lib/internal/ssaclient"
+)
+
+type certificateRequestObjectHelper struct {
+	readOnlyObj               *cmapi.CertificateRequest
+	setCAOnCertificateRequest bool
+}
+
+var _ RequestObjectHelper = &certificateRequestObjectHelper{}
+
+func (c *certificateRequestObjectHelper) IsApproved() bool {
+	return cmutil.CertificateRequestIsApproved(c.readOnlyObj)
+}
+
+func (c *certificateRequestObjectHelper) IsDenied() bool {
+	return cmutil.CertificateRequestHasCondition(c.readOnlyObj, cmapi.CertificateRequestCondition{
+		Type:   cmapi.CertificateRequestConditionReady,
+		Status: cmmeta.ConditionFalse,
+		Reason: cmapi.CertificateRequestReasonDenied,
+	})
+}
+
+func (c *certificateRequestObjectHelper) IsReady() bool {
+	return cmutil.CertificateRequestHasCondition(c.readOnlyObj, cmapi.CertificateRequestCondition{
+		Type:   cmapi.CertificateRequestConditionReady,
+		Status: cmmeta.ConditionTrue,
+	})
+}
+
+func (c *certificateRequestObjectHelper) IsFailed() bool {
+	return cmutil.CertificateRequestHasCondition(c.readOnlyObj, cmapi.CertificateRequestCondition{
+		Type:   cmapi.CertificateRequestConditionReady,
+		Status: cmmeta.ConditionFalse,
+		Reason: cmapi.CertificateRequestReasonFailed,
+	})
+}
+
+func (c *certificateRequestObjectHelper) RequestObject() signer.CertificateRequestObject {
+	return signer.CertificateRequestObjectFromCertificateRequest(c.readOnlyObj)
+}
+
+func (c *certificateRequestObjectHelper) NewPatch(
+	clock clock.PassiveClock,
+	fieldOwner string,
+	eventRecorder record.EventRecorder,
+) RequestPatchHelper {
+	return &certificateRequestPatchHelper{
+		clock:                     clock,
+		readOnlyObj:               c.readOnlyObj,
+		fieldOwner:                fieldOwner,
+		setCAOnCertificateRequest: c.setCAOnCertificateRequest,
+		patch:                     &cmapi.CertificateRequestStatus{},
+		eventRecorder:             eventRecorder,
+	}
+}
+
+type certificateRequestPatchHelper struct {
+	clock                     clock.PassiveClock
+	readOnlyObj               *cmapi.CertificateRequest
+	fieldOwner                string
+	setCAOnCertificateRequest bool
+
+	patch         *cmapi.CertificateRequestStatus
+	eventRecorder record.EventRecorder
+}
+
+var _ RequestPatchHelper = &certificateRequestPatchHelper{}
+var _ RequestPatch = &certificateRequestPatchHelper{}
+var _ CertificateRequestPatch = &certificateRequestPatchHelper{}
+
+func (c *certificateRequestPatchHelper) setCondition(
+	conditionType cmapi.CertificateRequestConditionType,
+	status cmmeta.ConditionStatus,
+	reason, message string,
+) (string, *metav1.Time) {
+	condition, updatedAt := conditions.SetCertificateRequestStatusCondition(
+		c.clock,
+		c.readOnlyObj.Status.Conditions,
+		&c.patch.Conditions,
+		conditionType, status,
+		reason, message,
+	)
+	return condition.Message, updatedAt
+}
+
+func (c *certificateRequestPatchHelper) SetInitializing() bool {
+	// If the CertificateRequest is already denied, we initialize/ overwrite to a failed Reason=Denied
+	// condition.
+	if cmutil.CertificateRequestIsDenied(c.readOnlyObj) {
+		message, failedAt := c.setCondition(
+			cmapi.CertificateRequestConditionReady,
+			cmmeta.ConditionFalse,
+			cmapi.CertificateRequestReasonDenied,
+			"Detected that the CertificateRequest is denied, so it will never be Ready.",
+		)
+		c.patch.FailureTime = failedAt.DeepCopy()
+		c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeWarning, eventRequestPermanentError, message)
+		return true
+	}
+
+	if ready := cmutil.GetCertificateRequestCondition(
+		c.readOnlyObj,
+		cmapi.CertificateRequestConditionReady,
+	); ready != nil {
+		return false
+	}
+
+	c.setCondition(
+		cmapi.CertificateRequestConditionReady,
+		cmmeta.ConditionUnknown,
+		v1alpha1.CertificateRequestConditionReasonInitializing,
+		fmt.Sprintf("%s has started reconciling this CertificateRequest", c.fieldOwner),
+	)
+	return true
+}
+
+func (c *certificateRequestPatchHelper) SetWaitingForIssuerExist(err error) {
+	message, _ := c.setCondition(
+		cmapi.CertificateRequestConditionReady,
+		cmmeta.ConditionFalse,
+		cmapi.CertificateRequestReasonPending,
+		fmt.Sprintf("%s. Waiting for it to be created.", err),
+	)
+	c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeNormal, eventRequestWaitingForIssuerExist, message)
+}
+
+func (c *certificateRequestPatchHelper) SetWaitingForIssuerReadyNoCondition() {
+	message, _ := c.setCondition(
+		cmapi.CertificateRequestConditionReady,
+		cmmeta.ConditionFalse,
+		cmapi.CertificateRequestReasonPending,
+		"Waiting for issuer to become ready. Current issuer ready condition: <none>.",
+	)
+	c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeNormal, eventRequestWaitingForIssuerReady, message)
+}
+
+func (c *certificateRequestPatchHelper) SetWaitingForIssuerReadyOutdated() {
+	message, _ := c.setCondition(
+		cmapi.CertificateRequestConditionReady,
+		cmmeta.ConditionFalse,
+		cmapi.CertificateRequestReasonPending,
+		"Waiting for issuer to become ready. Current issuer ready condition is outdated.",
+	)
+	c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeNormal, eventRequestWaitingForIssuerReady, message)
+}
+
+func (c *certificateRequestPatchHelper) SetWaitingForIssuerReadyNotReady(cond *cmapi.IssuerCondition) {
+	message, _ := c.setCondition(
+		cmapi.CertificateRequestConditionReady,
+		cmmeta.ConditionFalse,
+		cmapi.CertificateRequestReasonPending,
+		fmt.Sprintf("Waiting for issuer to become ready. Current issuer ready condition is \"%s\": %s.", cond.Reason, cond.Message),
+	)
+	c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeNormal, eventRequestWaitingForIssuerReady, message)
+}
+
+func (c *certificateRequestPatchHelper) SetCustomCondition(
+	conditionType string,
+	conditionStatus metav1.ConditionStatus,
+	conditionReason string, conditionMessage string,
+) bool {
+	c.setCondition(
+		cmapi.CertificateRequestConditionType(conditionType),
+		cmmeta.ConditionStatus(conditionStatus),
+		conditionReason,
+		conditionMessage,
+	)
+
+	// check if the custom condition transitioned
+	currentCustom := cmutil.GetCertificateRequestCondition(c.readOnlyObj, cmapi.CertificateRequestConditionType(conditionType))
+	didCustomConditionTransition := currentCustom == nil || currentCustom.Status != cmmeta.ConditionStatus(conditionStatus)
+	return didCustomConditionTransition
+}
+
+func (c *certificateRequestPatchHelper) SetUnexpectedError(err error) {
+	message := "Got an unexpected error while processing the CertificateRequest"
+	c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeWarning, eventRequestUnexpectedError, message)
+}
+
+func (c *certificateRequestPatchHelper) SetRetryableError(err error) {
+	message, _ := c.setCondition(
+		cmapi.CertificateRequestConditionReady,
+		cmmeta.ConditionFalse,
+		cmapi.CertificateRequestReasonPending,
+		fmt.Sprintf("Failed to sign CertificateRequest, will retry: %s", err),
+	)
+	c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeWarning, eventRequestRetryableError, message)
+}
+
+func (c *certificateRequestPatchHelper) SetPermanentError(err error) {
+	message, failedAt := c.setCondition(
+		cmapi.CertificateRequestConditionReady,
+		cmmeta.ConditionFalse,
+		cmapi.CertificateRequestReasonFailed,
+		fmt.Sprintf("Failed permanently to sign CertificateRequest: %s", err),
+	)
+	c.patch.FailureTime = failedAt.DeepCopy()
+	c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeWarning, eventRequestPermanentError, message)
+}
+
+func (c *certificateRequestPatchHelper) SetIssued(bundle signer.PEMBundle) {
+	c.patch.Certificate = bundle.ChainPEM
+	if c.setCAOnCertificateRequest {
+		c.patch.CA = bundle.CAPEM
+	}
+	message, _ := c.setCondition(
+		cmapi.CertificateRequestConditionReady,
+		cmmeta.ConditionTrue,
+		cmapi.CertificateRequestReasonIssued,
+		"Succeeded signing the CertificateRequest",
+	)
+	c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeNormal, eventRequestIssued, message)
+}
+
+func (c *certificateRequestPatchHelper) Patch() (client.Object, client.Patch, error) {
+	cr, patch, err := ssaclient.GenerateCertificateRequestStatusPatch(
+		c.readOnlyObj.Name,
+		c.readOnlyObj.Namespace,
+		c.patch,
+	)
+	return &cr, patch, err
+}
+
+func (c *certificateRequestPatchHelper) CertificateRequestPatch() *cmapi.CertificateRequestStatus {
+	return c.patch
+}

--- a/controllers/request_objecthelper_certificatesigningrequest.go
+++ b/controllers/request_objecthelper_certificatesigningrequest.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/util"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cert-manager/issuer-lib/conditions"
+	"github.com/cert-manager/issuer-lib/controllers/signer"
+	"github.com/cert-manager/issuer-lib/internal/ssaclient"
+)
+
+type certificatesigningRequestObjectHelper struct {
+	readOnlyObj *certificatesv1.CertificateSigningRequest
+}
+
+var _ RequestObjectHelper = &certificatesigningRequestObjectHelper{}
+
+func (c *certificatesigningRequestObjectHelper) IsApproved() bool {
+	return util.CertificateSigningRequestIsApproved(c.readOnlyObj)
+}
+
+func (c *certificatesigningRequestObjectHelper) IsDenied() bool {
+	return util.CertificateSigningRequestIsDenied(c.readOnlyObj)
+}
+
+func (c *certificatesigningRequestObjectHelper) IsReady() bool {
+	return len(c.readOnlyObj.Status.Certificate) > 0
+}
+
+func (c *certificatesigningRequestObjectHelper) IsFailed() bool {
+	return util.CertificateSigningRequestIsFailed(c.readOnlyObj)
+}
+
+func (c *certificatesigningRequestObjectHelper) RequestObject() signer.CertificateRequestObject {
+	return signer.CertificateRequestObjectFromCertificateSigningRequest(c.readOnlyObj)
+}
+
+func (c *certificatesigningRequestObjectHelper) NewPatch(
+	clock clock.PassiveClock,
+	fieldOwner string,
+	eventRecorder record.EventRecorder,
+) RequestPatchHelper {
+	return &certificatesigningRequestPatchHelper{
+		clock:         clock,
+		readOnlyObj:   c.readOnlyObj,
+		fieldOwner:    fieldOwner,
+		patch:         &certificatesv1.CertificateSigningRequestStatus{},
+		eventRecorder: eventRecorder,
+	}
+}
+
+type certificatesigningRequestPatchHelper struct {
+	clock       clock.PassiveClock
+	readOnlyObj *certificatesv1.CertificateSigningRequest
+	fieldOwner  string
+
+	patch         *certificatesv1.CertificateSigningRequestStatus
+	eventRecorder record.EventRecorder
+}
+
+var _ RequestPatchHelper = &certificatesigningRequestPatchHelper{}
+var _ RequestPatch = &certificatesigningRequestPatchHelper{}
+var _ CertificateSigningRequestPatch = &certificatesigningRequestPatchHelper{}
+
+func (c *certificatesigningRequestPatchHelper) setCondition(
+	conditionType certificatesv1.RequestConditionType,
+	status corev1.ConditionStatus,
+	reason, message string,
+) string {
+	condition, _ := conditions.SetCertificateSigningRequestStatusCondition(
+		c.clock,
+		c.readOnlyObj.Status.Conditions,
+		&c.patch.Conditions,
+		conditionType, status,
+		reason, message,
+	)
+	return condition.Message
+}
+
+func (c *certificatesigningRequestPatchHelper) SetInitializing() bool {
+	return false
+}
+
+func (c *certificatesigningRequestPatchHelper) SetWaitingForIssuerExist(err error) {
+	message := fmt.Sprintf("%s. Waiting for it to be created.", err)
+	c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeNormal, eventRequestWaitingForIssuerExist, message)
+}
+
+func (c *certificatesigningRequestPatchHelper) SetWaitingForIssuerReadyNoCondition() {
+	message := "Waiting for issuer to become ready. Current issuer ready condition: <none>."
+	c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeNormal, eventRequestWaitingForIssuerReady, message)
+}
+
+func (c *certificatesigningRequestPatchHelper) SetWaitingForIssuerReadyOutdated() {
+	message := "Waiting for issuer to become ready. Current issuer ready condition is outdated."
+	c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeNormal, eventRequestWaitingForIssuerReady, message)
+}
+
+func (c *certificatesigningRequestPatchHelper) SetWaitingForIssuerReadyNotReady(cond *cmapi.IssuerCondition) {
+	message := fmt.Sprintf("Waiting for issuer to become ready. Current issuer ready condition is \"%s\": %s.", cond.Reason, cond.Message)
+	c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeNormal, eventRequestWaitingForIssuerReady, message)
+}
+
+func (c *certificatesigningRequestPatchHelper) SetCustomCondition(
+	conditionType string,
+	conditionStatus metav1.ConditionStatus,
+	conditionReason string, conditionMessage string,
+) bool {
+	c.setCondition(
+		certificatesv1.RequestConditionType(conditionType),
+		corev1.ConditionStatus(conditionStatus),
+		conditionReason,
+		conditionMessage,
+	)
+
+	// check if the custom condition transitioned
+	currentCustom := conditions.GetCertificateSigningRequestStatusCondition(c.readOnlyObj.Status.Conditions, certificatesv1.RequestConditionType(conditionType))
+	didCustomConditionTransition := currentCustom == nil || currentCustom.Status != corev1.ConditionStatus(conditionStatus)
+	return didCustomConditionTransition
+}
+
+func (c *certificatesigningRequestPatchHelper) SetUnexpectedError(err error) {
+	message := "Got an unexpected error while processing the CertificateSigningRequest"
+	c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeWarning, eventRequestUnexpectedError, message)
+}
+
+func (c *certificatesigningRequestPatchHelper) SetRetryableError(err error) {
+	message := fmt.Sprintf("Failed to sign CertificateSigningRequest, will retry: %s", err)
+	c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeWarning, eventRequestRetryableError, message)
+}
+
+func (c *certificatesigningRequestPatchHelper) SetPermanentError(err error) {
+	message := c.setCondition(
+		certificatesv1.CertificateFailed,
+		corev1.ConditionTrue,
+		cmapi.CertificateRequestReasonFailed,
+		fmt.Sprintf("CertificateSigningRequest has failed permanently: %s", err),
+	)
+	c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeWarning, eventRequestPermanentError, message)
+}
+
+func (c *certificatesigningRequestPatchHelper) SetIssued(bundle signer.PEMBundle) {
+	c.patch.Certificate = bundle.ChainPEM
+	message := "Succeeded signing the CertificateSigningRequest"
+	c.eventRecorder.Event(c.readOnlyObj, corev1.EventTypeNormal, eventRequestIssued, message)
+}
+
+func (c *certificatesigningRequestPatchHelper) Patch() (client.Object, client.Patch, error) {
+	csr, patch, err := ssaclient.GenerateCertificateSigningRequestStatusPatch(
+		c.readOnlyObj.Name,
+		c.readOnlyObj.Namespace,
+		c.patch,
+	)
+	return &csr, patch, err
+}
+
+func (c *certificatesigningRequestPatchHelper) CertificateSigningRequestPatch() *certificatesv1.CertificateSigningRequestStatus {
+	return c.patch
+}

--- a/internal/ssaclient/patch.go
+++ b/internal/ssaclient/patch.go
@@ -34,3 +34,7 @@ func (p applyPatch) Data(_ client.Object) ([]byte, error) {
 func (p applyPatch) Type() types.PatchType {
 	return types.ApplyPatchType
 }
+
+func (p applyPatch) String() string {
+	return string(p.patch)
+}


### PR DESCRIPTION
Both the CertificateRequest and CertificateSigningRequest controllers were performing very similar actions.
This PR de-duplicate as much of the logic as possible.
This makes it much easier to make a change in the future without risking skew between both implementations.