### PR TITLE
Cleanup the CertificateRequest and CertificateSigningRequest controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It takes care of:
 - Updating the CertificateRequest status with the signed certificate data
 - Handling errors and retries
 - Handling CertificateRequest approval and denial
-- [FUTURE] Handle issuance of Kubernetes CSR resources
+- Handling issuance of Kubernetes CSR resources
 - [FUTURE] Provide a set of conformance tests for issuers
 
 ## Usage

--- a/controllers/certificaterequest_controller_integration_test.go
+++ b/controllers/certificaterequest_controller_integration_test.go
@@ -172,7 +172,7 @@ func TestCertificateRequestControllerIntegrationIssuerInitiallyNotFoundAndNotRea
 				if (readyCondition == nil) ||
 					(readyCondition.Status != cmmeta.ConditionFalse) ||
 					(readyCondition.Reason != cmapi.CertificateRequestReasonPending) ||
-					(readyCondition.Message != "Issuer is not Ready yet. No ready condition found. Waiting for it to become ready.") {
+					(readyCondition.Message != "Waiting for issuer to become ready. Current issuer ready condition: <none>.") {
 					return fmt.Errorf("incorrect ready condition: %v", readyCondition)
 				}
 
@@ -190,7 +190,7 @@ func TestCertificateRequestControllerIntegrationIssuerInitiallyNotFoundAndNotRea
 				if (readyCondition == nil) ||
 					(readyCondition.Status != cmmeta.ConditionTrue) ||
 					(readyCondition.Reason != cmapi.CertificateRequestReasonIssued) ||
-					(readyCondition.Message != "issued") {
+					(readyCondition.Message != "Succeeded signing the CertificateRequest") {
 					return fmt.Errorf("incorrect ready condition: %v", readyCondition)
 				}
 
@@ -294,7 +294,7 @@ func TestCertificateRequestControllerIntegrationSetCondition(t *testing.T) {
 		if (readyCondition == nil) ||
 			(readyCondition.Status != cmmeta.ConditionFalse) ||
 			(readyCondition.Reason != cmapi.CertificateRequestReasonPending) ||
-			(readyCondition.Message != "Issuer is not Ready yet. No ready condition found. Waiting for it to become ready.") {
+			(readyCondition.Message != "Waiting for issuer to become ready. Current issuer ready condition: <none>.") {
 			return fmt.Errorf("incorrect ready condition: %v", readyCondition)
 		}
 
@@ -357,7 +357,7 @@ func TestCertificateRequestControllerIntegrationSetCondition(t *testing.T) {
 		if (readyCondition == nil) ||
 			(readyCondition.Status != cmmeta.ConditionTrue) ||
 			(readyCondition.Reason != cmapi.CertificateRequestReasonIssued) ||
-			(readyCondition.Message != "issued") {
+			(readyCondition.Message != "Succeeded signing the CertificateRequest") {
 			return fmt.Errorf("incorrect ready condition: %v", readyCondition)
 		}
 

--- a/controllers/combined_controller_integration_test.go
+++ b/controllers/combined_controller_integration_test.go
@@ -104,13 +104,13 @@ func TestCombinedControllerTemporaryFailedCertificateRequestRetrigger(t *testing
 				Type:    cmapi.IssuerConditionReady,
 				Status:  cmmeta.ConditionFalse,
 				Reason:  v1alpha1.IssuerConditionReasonPending,
-				Message: "Issuer is not ready yet: [error message]",
+				Message: "Not ready yet: [error message]",
 			},
 			certificateReadyCondition: &cmapi.CertificateRequestCondition{
 				Type:    cmapi.CertificateRequestConditionReady,
 				Status:  cmmeta.ConditionFalse,
 				Reason:  cmapi.CertificateRequestReasonPending,
-				Message: "Issuer is not Ready yet. Current ready condition is \"Pending\": Issuer is not ready yet: [error message]. Waiting for it to become ready.",
+				Message: "Waiting for issuer to become ready. Current issuer ready condition is \"Pending\": Not ready yet: [error message].",
 			},
 			checkAutoRecovery: true,
 		},
@@ -121,13 +121,13 @@ func TestCombinedControllerTemporaryFailedCertificateRequestRetrigger(t *testing
 				Type:    cmapi.IssuerConditionReady,
 				Status:  cmmeta.ConditionFalse,
 				Reason:  v1alpha1.IssuerConditionReasonFailed,
-				Message: "Issuer has failed permanently: [error message]",
+				Message: "Failed permanently: [error message]",
 			},
 			certificateReadyCondition: &cmapi.CertificateRequestCondition{
 				Type:    cmapi.CertificateRequestConditionReady,
 				Status:  cmmeta.ConditionFalse,
 				Reason:  cmapi.CertificateRequestReasonPending,
-				Message: "Issuer is not Ready yet. Current ready condition is \"Failed\": Issuer has failed permanently: [error message]. Waiting for it to become ready.",
+				Message: "Waiting for issuer to become ready. Current issuer ready condition is \"Failed\": Failed permanently: [error message].",
 			},
 			checkAutoRecovery: false,
 		},
@@ -200,7 +200,7 @@ func TestCombinedControllerTemporaryFailedCertificateRequestRetrigger(t *testing
 				if (readyCondition == nil) ||
 					(readyCondition.Status != cmmeta.ConditionFalse) ||
 					(readyCondition.Reason != cmapi.CertificateRequestReasonPending) ||
-					(readyCondition.Message != "Issuer is not Ready yet. Current ready condition is outdated. Waiting for it to become ready.") {
+					(readyCondition.Message != "Waiting for issuer to become ready. Current issuer ready condition is outdated.") {
 					return fmt.Errorf("incorrect ready condition: %v", readyCondition)
 				}
 
@@ -267,7 +267,7 @@ func TestCombinedControllerTemporaryFailedCertificateRequestRetrigger(t *testing
 					if (readyCondition == nil) ||
 						(readyCondition.Status != cmmeta.ConditionTrue) ||
 						(readyCondition.Reason != cmapi.CertificateRequestReasonIssued) ||
-						(readyCondition.Message != "issued") {
+						(readyCondition.Message != "Succeeded signing the CertificateRequest") {
 						return fmt.Errorf("incorrect ready condition: %v", readyCondition)
 					}
 

--- a/controllers/issuer_controller_test.go
+++ b/controllers/issuer_controller_test.go
@@ -202,7 +202,7 @@ func TestSimpleIssuerReconcilerReconcile(t *testing.T) {
 						Type:               cmapi.IssuerConditionReady,
 						Status:             cmmeta.ConditionFalse,
 						Reason:             v1alpha1.IssuerConditionReasonPending,
-						Message:            "Issuer is not ready yet: [specific error]",
+						Message:            "Not ready yet: [specific error]",
 						ObservedGeneration: 80,
 						LastTransitionTime: &fakeTimeObj2,
 					},
@@ -210,7 +210,7 @@ func TestSimpleIssuerReconcilerReconcile(t *testing.T) {
 			},
 			validateError: errormatch.ErrorContains("[specific error]"),
 			expectedEvents: []string{
-				"Warning RetryableError Issuer is not ready yet: [specific error]",
+				"Warning RetryableError Not ready yet: [specific error]",
 			},
 		},
 
@@ -288,14 +288,14 @@ func TestSimpleIssuerReconcilerReconcile(t *testing.T) {
 						Type:               cmapi.IssuerConditionReady,
 						Status:             cmmeta.ConditionFalse,
 						Reason:             v1alpha1.IssuerConditionReasonPending,
-						Message:            "Issuer is not ready yet: [specific error]",
+						Message:            "Not ready yet: [specific error]",
 						LastTransitionTime: &fakeTimeObj2,
 					},
 				},
 			},
 			validateError: errormatch.ErrorContains("[specific error]"),
 			expectedEvents: []string{
-				"Warning RetryableError Issuer is not ready yet: [specific error]",
+				"Warning RetryableError Not ready yet: [specific error]",
 			},
 		},
 
@@ -320,14 +320,14 @@ func TestSimpleIssuerReconcilerReconcile(t *testing.T) {
 						Type:               cmapi.IssuerConditionReady,
 						Status:             cmmeta.ConditionFalse,
 						Reason:             v1alpha1.IssuerConditionReasonFailed,
-						Message:            "Issuer has failed permanently: [specific error]",
+						Message:            "Failed permanently: [specific error]",
 						LastTransitionTime: &fakeTimeObj2,
 					},
 				},
 			},
 			validateError: errormatch.ErrorContains("terminal error: [specific error]"),
 			expectedEvents: []string{
-				"Warning PermanentError Issuer has failed permanently: [specific error]",
+				"Warning PermanentError Failed permanently: [specific error]",
 			},
 		},
 


### PR DESCRIPTION
This PR updates the Message in some of the CR & CSR conditions to match the event messages.
It also introduces the use of c/r TerminalError.

Split from #43 