### PR TITLE
Try grouping the dependabot upgrades

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,13 @@ updates:
   directory: /
   schedule:
     interval: weekly
+  groups:
+    all:
+      patterns: ["*"]
 - package-ecosystem: github-actions
   directory: /
   schedule:
     interval: weekly
+  groups:
+    all:
+      patterns: ["*"]


### PR DESCRIPTION
I tried to add grouping options for dependabot, this should make dependabot create single grouped PRs to upgrade deps.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups