### PR TITLE
Make CertificateRequestObject interface more intuitive

### DIFF
--- a/controllers/signer/interface.go
+++ b/controllers/signer/interface.go
@@ -74,6 +74,15 @@ type CertificateDetails struct {
 	ExtKeyUsage []x509.ExtKeyUsage
 }
 
+// CertificateTemplate generates a certificate template for issuance,
+// based on CertificateDetails extracted from the CertificateRequest or
+// CertificateSigningRequest resource.
+//
+// This function internally calls CertificateTemplateFromCSRPEM, which performs
+// additional work such as parsing the CSR and verifying signatures. Since this
+// operation can be expensive, issuer implementations should call this function
+// only when a certificate template is actually needed (e.g., not when proxying
+// the X.509 CSR to a CA).
 func (cd CertificateDetails) CertificateTemplate() (template *x509.Certificate, err error) {
 	return pki.CertificateTemplateFromCSRPEM(
 		cd.CSR,

--- a/examples/simple/controller/signer.go
+++ b/examples/simple/controller/signer.go
@@ -88,7 +88,12 @@ func (Signer) Sign(ctx context.Context, cr signer.CertificateRequestObject, issu
 	}
 
 	// load client certificate request
-	clientCRTTemplate, _, _, err := cr.GetRequest()
+	certDetails, err := cr.GetCertificateDetails()
+	if err != nil {
+		return signer.PEMBundle{}, err
+	}
+
+	clientCRTTemplate, err := certDetails.CertificateTemplate()
 	if err != nil {
 		return signer.PEMBundle{}, err
 	}


### PR DESCRIPTION
Instead of the `GetRequest` function which returned a few certificate properties, we now return a `CertificateDetails` struct which contains all properties extracted from the CertificateRequest/ CertificateSigningRequest as well as the CSR.
To create a template based on this `CertificateDetails` struct, we can now use the `CertificateTemplate` function.

NOTE: this is a breaking change, but as indicated in the README of this repo: "This library's API is still subject to change"