### PR TITLE
Fix certificaterequest denial status

### DIFF
--- a/controllers/certificaterequest_controller_test.go
+++ b/controllers/certificaterequest_controller_test.go
@@ -266,6 +266,38 @@ func TestCertificateRequestReconcilerReconcile(t *testing.T) {
 			},
 		},
 
+		// If denied before the issuer has added any conditions, set Ready condition status to
+		// false and reason to denied.
+		{
+			name: "set-ready-denied-without-approved-or-ready",
+			objects: []client.Object{
+				cmgen.CertificateRequestFrom(cr1,
+					func(cr *cmapi.CertificateRequest) {
+						cr.Status.Conditions = nil
+					},
+					cmgen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+						Type:   cmapi.CertificateRequestConditionDenied,
+						Status: cmmeta.ConditionTrue,
+					}),
+				),
+			},
+			expectedStatusPatch: &cmapi.CertificateRequestStatus{
+				Conditions: []cmapi.CertificateRequestCondition{
+					{
+						Type:               cmapi.CertificateRequestConditionReady,
+						Status:             cmmeta.ConditionFalse,
+						Reason:             cmapi.CertificateRequestReasonDenied,
+						Message:            "Detected that the CertificateRequest is denied, so it will never be Ready.",
+						LastTransitionTime: &fakeTimeObj2,
+					},
+				},
+				FailureTime: &fakeTimeObj2,
+			},
+			expectedEvents: []string{
+				"Warning PermanentError Detected that the CertificateRequest is denied, so it will never be Ready.",
+			},
+		},
+
 		// If issuer is missing, set Ready condition status to false and reason to pending.
 		{
 			name: "set-ready-pending-missing-issuer",

--- a/controllers/request_controller.go
+++ b/controllers/request_controller.go
@@ -180,7 +180,7 @@ func (r *RequestController) reconcileStatusPatch(
 
 	// Ignore Request if it has not yet been assigned an approval
 	// status condition by an approval controller.
-	if !requestObjectHelper.IsApproved() && !requestObjectHelper.IsDenied() {
+	if !requestObjectHelper.IsApproved() && !requestObjectHelper.IsDeniedByApprover() {
 		logger.V(1).Info("Request has not been approved or denied. Ignoring.")
 		return result, nil, nil // done
 	}

--- a/controllers/request_objecthelper.go
+++ b/controllers/request_objecthelper.go
@@ -41,6 +41,7 @@ const (
 
 type RequestObjectHelper interface {
 	IsApproved() bool
+	IsDeniedByApprover() bool
 	IsDenied() bool
 	IsReady() bool
 	IsFailed() bool

--- a/controllers/request_objecthelper_certificaterequest.go
+++ b/controllers/request_objecthelper_certificaterequest.go
@@ -45,6 +45,11 @@ func (c *certificateRequestObjectHelper) IsApproved() bool {
 	return cmutil.CertificateRequestIsApproved(c.readOnlyObj)
 }
 
+// IsDeniedByApprover reports whether an approver set the Denied condition
+func (c *certificateRequestObjectHelper) IsDeniedByApprover() bool {
+	return cmutil.CertificateRequestIsDenied(c.readOnlyObj)
+}
+
 func (c *certificateRequestObjectHelper) IsDenied() bool {
 	return cmutil.CertificateRequestHasCondition(c.readOnlyObj, cmapi.CertificateRequestCondition{
 		Type:   cmapi.CertificateRequestConditionReady,

--- a/controllers/request_objecthelper_certificatesigningrequest.go
+++ b/controllers/request_objecthelper_certificatesigningrequest.go
@@ -43,6 +43,11 @@ func (c *certificatesigningRequestObjectHelper) IsApproved() bool {
 	return util.CertificateSigningRequestIsApproved(c.readOnlyObj)
 }
 
+// IsDeniedByApprover reports whether an approver set the Denied condition
+func (c *certificatesigningRequestObjectHelper) IsDeniedByApprover() bool {
+	return util.CertificateSigningRequestIsDenied(c.readOnlyObj)
+}
+
 func (c *certificatesigningRequestObjectHelper) IsDenied() bool {
 	return util.CertificateSigningRequestIsDenied(c.readOnlyObj)
 }


### PR DESCRIPTION
### Pull Request Motivation

Fixes #507 

This fixes issuer-lib handling of a CertificateRequest which has `Denied=True` but no `Approved` or `Ready` condition.

The first controller gate previously used `IsDenied()`. For CertificateRequests, that method checks whether issuer-lib already added `Ready=False` with reason `Denied`. It does not check the approver's `Denied=True` condition.

The controller therefore returned before it could record the terminal status.

The linked issue contains the full reproduction steps, observed behavior and impact.

### What changed

This PR adds a separate `IsDeniedByApprover()` check.

- The CertificateRequest implementation checks the cert-manager `Denied` condition.
- The first controller gate uses the new check.
- The existing `IsDenied()` check still detects the terminal `Ready=False` condition.
- The CertificateSigningRequest implementation keeps its existing behavior.
- A regression test covers a request with only `Denied=True`.

The denied CertificateRequest now gets:

- `Ready=False` with reason `Denied`
- `status.failureTime`
- the existing `Warning PermanentError` event

### Kind

/kind bug

### Verification

The new regression test fails on the old code because no status patch or event is produced. It passes with this fix.

The following checks pass:

```console
go vet ./...
go test ./...
./_bin/tools/golangci-lint run
cd examples/simple && ../../_bin/tools/golangci-lint run
cd examples/upstream && ../../_bin/tools/golangci-lint run
```

The fix was also checked with the official sample issuer in Kind.

Before the fix:

- The request had only `Denied=True`.
- It had no `Ready` condition or failure time.
- The owning Certificate failed.
- No signing request was sent.

After the fix:

- The request had `Denied=True`.
- It had `Ready=False` with reason `Denied`.
- Its failure time was set.
- The warning event was emitted.
- The owning Certificate still failed.
- No signing request was sent.

### Release Note

```release-note
Denied CertificateRequests now get a Ready=False condition with reason Denied, a failure time and a warning event.
```