### PR TITLE
Default empty issuerRef group and kind for in-tree cert-manager issuer types

### DIFF
--- a/controllers/certificaterequest_controller.go
+++ b/controllers/certificaterequest_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cert-manager/cert-manager/pkg/apis/certmanager"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -53,12 +54,36 @@ func (r *CertificateRequestReconciler) matchIssuerType(requestObject client.Obje
 		return nil, types.NamespacedName{}, fmt.Errorf("invalid reference, CertificateRequest is nil")
 	}
 
+	// cert-manager core does not default issuerRef.group or issuerRef.kind on
+	// stored objects (the CRD has no defaults for issuerRef), yet users
+	// routinely omit them. Core resolves an omitted group to "cert-manager.io"
+	// and an omitted kind to "Issuer". For in-tree issuer types (see the
+	// intree package) we must apply the same rules so that this controller
+	// and core agree on which issuer a CertificateRequest refers to.
+	//
+	// The group default is unconditional, but the kind default only applies
+	// to the cert-manager.io group: for third-party groups core has no
+	// opinion, and issuer-lib keeps its behaviour of treating an empty kind
+	// as a wildcard that matches the first registered type.
+	group := cr.Spec.IssuerRef.Group
+	if group == "" {
+		group = certmanager.GroupName
+	}
+
 	// Search for matching issuer
 	for _, issuerType := range r.AllIssuerTypes() {
 		gvk := issuerType.Type.GetObjectKind().GroupVersionKind()
 
-		if (cr.Spec.IssuerRef.Group != gvk.Group) ||
-			(cr.Spec.IssuerRef.Kind != "" && cr.Spec.IssuerRef.Kind != gvk.Kind) {
+		if group != gvk.Group {
+			continue
+		}
+
+		kind := cr.Spec.IssuerRef.Kind
+		if kind == "" && gvk.Group == certmanager.GroupName {
+			kind = cmapi.IssuerKind
+		}
+
+		if kind != "" && kind != gvk.Kind {
 			continue
 		}
 
@@ -75,7 +100,7 @@ func (r *CertificateRequestReconciler) matchIssuerType(requestObject client.Obje
 		return issuerObject, issuerName, nil
 	}
 
-	return nil, types.NamespacedName{}, fmt.Errorf("no issuer found for reference: [Group=%q, Kind=%q, Name=%q]", cr.Spec.IssuerRef.Group, cr.Spec.IssuerRef.Kind, cr.Spec.IssuerRef.Name)
+	return nil, types.NamespacedName{}, fmt.Errorf("no issuer found for reference: [Group=%q, Kind=%q, Name=%q]", group, cr.Spec.IssuerRef.Kind, cr.Spec.IssuerRef.Name)
 }
 
 func (r *CertificateRequestReconciler) Init() *CertificateRequestReconciler {

--- a/controllers/certificaterequest_controller_test.go
+++ b/controllers/certificaterequest_controller_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cert-manager/issuer-lib/internal/testapi/api"
 	"github.com/cert-manager/issuer-lib/internal/testapi/testutil"
 	"github.com/cert-manager/issuer-lib/internal/tests/errormatch"
+	"github.com/cert-manager/issuer-lib/intree"
 )
 
 func TestCertificateRequestReconcilerReconcile(t *testing.T) {
@@ -1070,10 +1071,82 @@ func TestCertificateRequestMatchIssuerType(t *testing.T) {
 			expectedIssuerType: &api.TestIssuer{},
 			expectedIssuerName: types.NamespacedName{Name: "name", Namespace: "namespace"},
 		},
+		{
+			name:               "empty group matches in-tree cert-manager Issuer",
+			issuerTypes:        intree.Issuers,
+			clusterIssuerTypes: intree.ClusterIssuers,
+			cr:                 createCr("name", "namespace", "", ""),
+
+			expectedIssuerType: &intree.CMIssuer{},
+			expectedIssuerName: types.NamespacedName{Name: "name", Namespace: "namespace"},
+		},
+		{
+			name:               "empty group matches in-tree cert-manager ClusterIssuer",
+			issuerTypes:        intree.Issuers,
+			clusterIssuerTypes: intree.ClusterIssuers,
+			cr:                 createCr("name", "namespace", cmapi.ClusterIssuerKind, ""),
+
+			expectedIssuerType: &intree.CMClusterIssuer{},
+			expectedIssuerName: types.NamespacedName{Name: "name"},
+		},
+		{
+			name:               "explicit cert-manager.io group matches in-tree cert-manager Issuer",
+			issuerTypes:        intree.Issuers,
+			clusterIssuerTypes: intree.ClusterIssuers,
+			cr:                 createCr("name", "namespace", cmapi.IssuerKind, cmapi.SchemeGroupVersion.Group),
+
+			expectedIssuerType: &intree.CMIssuer{},
+			expectedIssuerName: types.NamespacedName{Name: "name", Namespace: "namespace"},
+		},
+		{
+			name:               "empty group does not match third-party issuer",
+			issuerTypes:        []v1alpha1.Issuer{&api.TestIssuer{}},
+			clusterIssuerTypes: []v1alpha1.Issuer{&api.TestClusterIssuer{}},
+			cr:                 createCr("name", "namespace", "", ""),
+
+			expectedError: errormatch.ErrorContains("no issuer found for reference"),
+		},
+		{
+			name:               "third-party group does not match in-tree cert-manager issuers",
+			issuerTypes:        intree.Issuers,
+			clusterIssuerTypes: intree.ClusterIssuers,
+			cr:                 createCr("name", "namespace", "", "testing.cert-manager.io"),
+
+			expectedError: errormatch.ErrorContains("no issuer found for reference"),
+		},
+		{
+			// cert-manager core resolves an empty kind to Issuer, so a
+			// controller that only registers the in-tree ClusterIssuer must
+			// not claim such a request.
+			name:               "empty kind defaults to Issuer for cert-manager.io group",
+			issuerTypes:        nil,
+			clusterIssuerTypes: intree.ClusterIssuers,
+			cr:                 createCr("name", "namespace", "", ""),
+
+			expectedError: errormatch.ErrorContains("no issuer found for reference: [Group=\"cert-manager.io\", Kind=\"\", Name=\"name\"]"),
+		},
+		{
+			name:               "empty kind defaults to Issuer for explicit cert-manager.io group",
+			issuerTypes:        nil,
+			clusterIssuerTypes: intree.ClusterIssuers,
+			cr:                 createCr("name", "namespace", "", cmapi.SchemeGroupVersion.Group),
+
+			expectedError: errormatch.ErrorContains("no issuer found for reference"),
+		},
+		{
+			name:               "empty kind with cert-manager.io group selects Issuer when both registered",
+			issuerTypes:        intree.Issuers,
+			clusterIssuerTypes: intree.ClusterIssuers,
+			cr:                 createCr("name", "namespace", "", cmapi.SchemeGroupVersion.Group),
+
+			expectedIssuerType: &intree.CMIssuer{},
+			expectedIssuerName: types.NamespacedName{Name: "name", Namespace: "namespace"},
+		},
 	}
 
 	scheme := runtime.NewScheme()
 	require.NoError(t, api.AddToScheme(scheme))
+	require.NoError(t, cmapi.AddToScheme(scheme))
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1091,7 +1164,7 @@ func TestCertificateRequestMatchIssuerType(t *testing.T) {
 			issuerType, issuerName, err := crr.matchIssuerType(tc.cr)
 
 			if tc.expectedIssuerType != nil {
-				require.NoError(t, kubeutil.SetGroupVersionKind(scheme, tc.expectedIssuerType))
+				require.NoError(t, kubeutil.SetGroupVersionKind(scheme, kubeutil.ObjectForIssuer(tc.expectedIssuerType)))
 			}
 
 			assert.Equal(t, tc.expectedIssuerType, issuerType)

--- a/intree/README.md
+++ b/intree/README.md
@@ -27,3 +27,17 @@ func (s Signer) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	}).SetupWithManager(ctx, mgr)
 }
 ```
+
+## Matching `issuerRef`
+
+cert-manager does not default `issuerRef.group` or `issuerRef.kind` on stored `CertificateRequest`
+resources, and users routinely omit them. To stay compatible with cert-manager, the request controllers
+resolve references to the in-tree types the same way cert-manager does:
+
+* An empty `issuerRef.group` is treated as `cert-manager.io`.
+* An empty `issuerRef.kind` is treated as `Issuer` (never `ClusterIssuer`) when the group is `cert-manager.io`.
+
+So `issuerRef: {name: foo}` is matched against `intree.Issuers` as `Issuer/foo` in the request's namespace.
+A request that only sets `kind: ClusterIssuer` is matched against `intree.ClusterIssuers`. These defaults
+apply only to the `cert-manager.io` group; for third-party issuer types an empty kind still matches the
+first registered type.


### PR DESCRIPTION
https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_vault-issuer/93/pull-cert-manager-vault-issuer-e2e/2095165615277871104 Our internal vault issuer tests are failing because the certs created have no groups by default. Since the group for internal types is `cert-manager.io` but the cert created itself doesn't have group its ignored